### PR TITLE
Add a pluggable identity system

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -8,14 +8,15 @@ RUN apt-get install -y \
 	build-essential chrpath libssl-dev \
 	libxft-dev libfreetype6 libfreetype6-dev \
 	libpng-dev libjpeg62-turbo-dev \
-	libfontconfig1 libfontconfig1-dev libzip-dev
+	libfontconfig1 libfontconfig1-dev libzip-dev libldap2-dev
 
 RUN pecl install mcrypt-1.0.2 && \
 	docker-php-ext-enable mcrypt
 
 RUN docker-php-ext-configure intl && \
+    docker-php-ext-configure ldap && \
 	docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
-	docker-php-ext-install opcache pdo_mysql zip intl gd
+	docker-php-ext-install opcache pdo_mysql zip intl gd ldap
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.php]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /data
 /MULTIPLY
 /include.php
+.idea/

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Actions.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Actions.php
@@ -2,11 +2,9 @@
 
 namespace RainLoop;
 
-use RainLoop\Enumerations\UploadError;
 use RainLoop\Enumerations\UploadClientError;
-use RainLoop\Model\Identity;
+use RainLoop\Enumerations\UploadError;
 use RainLoop\Providers\Identities;
-use RainLoop\Providers\Storage\Enumerations\StorageType;
 
 class Actions
 {
@@ -58,9 +56,9 @@ class Actions
 	 */
 	private $aCachers;
 
-    /**
-     * @var Providers\Identities
-     */
+	/**
+	 * @var Providers\Identities
+	 */
 	private $oIdentitiesProvider;
 
 	/**
@@ -151,47 +149,46 @@ class Actions
 		$this->Logger()->Ping();
 	}
 
-	public function SetSpecAuthToken(string $sSpecAuthToken) : self
+	public function SetSpecAuthToken(string $sSpecAuthToken): self
 	{
 		$this->sSpecAuthToken = $sSpecAuthToken;
 
 		return $this;
 	}
 
-	public function SetUpdateAuthToken(string $sUpdateAuthToken) : self
+	public function SetUpdateAuthToken(string $sUpdateAuthToken): self
 	{
 		$this->sUpdateAuthToken = $sUpdateAuthToken;
 
 		return $this;
 	}
 
-	public function SetIsAjax(bool $bIsAjax) : self
+	public function SetIsAjax(bool $bIsAjax): self
 	{
 		$this->bIsAjax = $bIsAjax;
 
 		return $this;
 	}
 
-	public function GetSpecAuthToken() : string
+	public function GetSpecAuthToken(): string
 	{
 		return $this->sSpecAuthToken;
 	}
 
-	public function GetUpdateAuthToken() : string
+	public function GetUpdateAuthToken(): string
 	{
 		return $this->sUpdateAuthToken;
 	}
 
-	public function GetIsAjax() : bool
+	public function GetIsAjax(): bool
 	{
 		return $this->bIsAjax;
 	}
 
-	public function GetShortLifeSpecAuthToken(int $iLife = 60) : string
+	public function GetShortLifeSpecAuthToken(int $iLife = 60): string
 	{
 		$aAccountHash = Utils::DecodeKeyValues($this->getLocalAuthToken());
-		if (!empty($aAccountHash[0]) && 'token' === $aAccountHash[0])
-		{
+		if (!empty($aAccountHash[0]) && 'token' === $aAccountHash[0]) {
 			$aAccountHash[10] = \time() + $iLife;
 			return Utils::EncodeKeyValues($aAccountHash);
 		}
@@ -199,13 +196,11 @@ class Actions
 		return '';
 	}
 
-	public function Config() : Config\Application
+	public function Config(): Config\Application
 	{
-		if (null === $this->oConfig)
-		{
+		if (null === $this->oConfig) {
 			$this->oConfig = new Config\Application();
-			if (!$this->oConfig->Load())
-			{
+			if (!$this->oConfig->Load()) {
 				usleep(10000);
 				$this->oConfig->Load();
 			}
@@ -237,19 +232,17 @@ class Actions
 		$mResult = null;
 		$this->Plugins()->RunHook('main.fabrica', array($sName, &$mResult), false);
 
-		if (null === $mResult)
-		{
-			switch ($sName)
-			{
+		if (null === $mResult) {
+			switch ($sName) {
 				case 'files':
 					// RainLoop\Providers\Files\IFiles
-					$mResult = new Providers\Files\FileStorage(APP_PRIVATE_DATA.'storage/files');
+					$mResult = new Providers\Files\FileStorage(APP_PRIVATE_DATA . 'storage/files');
 					break;
 				case 'storage':
 				case 'storage-local':
 					// RainLoop\Providers\Storage\IStorage
 					$mResult = new Providers\Storage\FileStorage(
-						APP_PRIVATE_DATA.'storage', 'storage-local' === $sName);
+						APP_PRIVATE_DATA . 'storage', 'storage-local' === $sName);
 					break;
 				case 'settings':
 				case 'settings-local':
@@ -263,7 +256,7 @@ class Actions
 					break;
 				case 'domain':
 					// Providers\Domain\DomainAdminInterface
-					$mResult = new Providers\Domain\DefaultDomain(APP_PRIVATE_DATA.'domains', $this->Cacher());
+					$mResult = new Providers\Domain\DefaultDomain(APP_PRIVATE_DATA . 'domains', $this->Cacher());
 					break;
 				case 'filters':
 					// Providers\Filters\FiltersInterface
@@ -276,16 +269,13 @@ class Actions
 
 					$sDsn = \trim($this->Config()->Get('contacts', 'pdo_dsn', ''));
 					$sUser = \trim($this->Config()->Get('contacts', 'pdo_user', ''));
-					$sPassword = (string) $this->Config()->Get('contacts', 'pdo_password', '');
+					$sPassword = (string)$this->Config()->Get('contacts', 'pdo_password', '');
 
 					$sDsnType = $this->ValidateContactPdoType(\trim($this->Config()->Get('contacts', 'type', 'sqlite')));
-					if ('sqlite' === $sDsnType)
-					{
+					if ('sqlite' === $sDsnType) {
 						$mResult = new Providers\AddressBook\PdoAddressBook(
-							'sqlite:'.APP_PRIVATE_DATA.'AddressBook.sqlite', '', '', 'sqlite');
-					}
-					else
-					{
+							'sqlite:' . APP_PRIVATE_DATA . 'AddressBook.sqlite', '', '', 'sqlite');
+					} else {
 						$mResult = new Providers\AddressBook\PdoAddressBook($sDsn, $sUser, $sPassword, $sDsnType);
 					}
 					break;
@@ -298,16 +288,14 @@ class Actions
 			}
 		}
 
-        // Always give the file provider as last for identities, it is the override
-		if($sName === 'identities') {
-            if($mResult === null) $mResult = [];
-            $mResult[] = new Providers\Identities\FileIdentities($this->StorageProvider(true));
-        }
+		// Always give the file provider as last for identities, it is the override
+		if ($sName === 'identities') {
+			if ($mResult === null) $mResult = [];
+			$mResult[] = new Providers\Identities\FileIdentities($this->StorageProvider(true));
+		}
 
-		foreach (\is_array($mResult) ? $mResult : array($mResult) as $oItem)
-		{
-			if ($oItem && \method_exists($oItem, 'SetLogger'))
-			{
+		foreach (\is_array($mResult) ? $mResult : array($mResult) as $oItem) {
+			if ($oItem && \method_exists($oItem, 'SetLogger')) {
 				$oItem->SetLogger($this->Logger());
 			}
 		}
@@ -317,48 +305,42 @@ class Actions
 		return $mResult;
 	}
 
-	public function BootEnd() : void
+	public function BootEnd(): void
 	{
-		try
-		{
-			if ($this->MailClient()->IsLoggined())
-			{
+		try {
+			if ($this->MailClient()->IsLoggined()) {
 				$this->MailClient()->LogoutAndDisconnect();
 			}
+		} catch (\Throwable $oException) {
+			unset($oException);
 		}
-		catch (\Throwable $oException) { unset($oException); }
 	}
 
-	public function ParseQueryAuthString() : string
+	public function ParseQueryAuthString(): string
 	{
 		$sQuery = \trim($this->Http()->GetQueryString());
 
 		$iPos = \strpos($sQuery, '&');
-		if (0 < $iPos)
-		{
+		if (0 < $iPos) {
 			$sQuery = \substr($sQuery, 0, $iPos);
 		}
 
 		$sQuery = \trim(\trim($sQuery), ' /');
 
 		$aSubQuery = $this->Http()->GetQuery('q');
-		if (\is_array($aSubQuery))
-		{
+		if (\is_array($aSubQuery)) {
 			$aSubQuery = \array_map(function ($sS) {
 				return \trim(\trim($sS), ' /');
 			}, $aSubQuery);
 
-			if (0 < \count($aSubQuery))
-			{
-				$sQuery .= '/'.\implode('/', $aSubQuery);
+			if (0 < \count($aSubQuery)) {
+				$sQuery .= '/' . \implode('/', $aSubQuery);
 			}
 		}
 
-		if ('' === $this->GetSpecAuthToken())
-		{
+		if ('' === $this->GetSpecAuthToken()) {
 			$aPaths = \explode('/', $sQuery);
-			if (!empty($aPaths[0]) && !empty($aPaths[1]) && '_' === substr($aPaths[1], 0, 1))
-			{
+			if (!empty($aPaths[0]) && !empty($aPaths[1]) && '_' === substr($aPaths[1], 0, 1)) {
 				$this->SetSpecAuthToken($aPaths[1]);
 			}
 		}
@@ -366,13 +348,12 @@ class Actions
 		return $sQuery;
 	}
 
-	private function compileLogParams(string $sLine, ?Model\Account $oAccount = null, bool $bUrlEncode = false, array $aAdditionalParams = array()) : string
+	private function compileLogParams(string $sLine, ?Model\Account $oAccount = null, bool $bUrlEncode = false, array $aAdditionalParams = array()): string
 	{
 		$aClear = array();
 
-		if (false !== \strpos($sLine, '{date:'))
-		{
-			$sTimeOffset = (string) $this->Config()->Get('logs', 'time_offset', '0');
+		if (false !== \strpos($sLine, '{date:')) {
+			$sTimeOffset = (string)$this->Config()->Get('logs', 'time_offset', '0');
 			$sLine = \preg_replace_callback('/\{date:([^}]+)\}/', function ($aMatch) use ($sTimeOffset, $bUrlEncode) {
 				return Utils::UrlEncode(\MailSo\Log\Logger::DateHelper($aMatch[1], $sTimeOffset), $bUrlEncode);
 			}, $sLine);
@@ -380,16 +361,13 @@ class Actions
 			$aClear['/\{date:([^}]*)\}/'] = 'date';
 		}
 
-		if (false !== \strpos($sLine, '{imap:') || false !== \strpos($sLine, '{smtp:'))
-		{
-			if (!$oAccount)
-			{
+		if (false !== \strpos($sLine, '{imap:') || false !== \strpos($sLine, '{smtp:')) {
+			if (!$oAccount) {
 				$this->ParseQueryAuthString();
 				$oAccount = $this->getAccountFromToken(false);
 			}
 
-			if ($oAccount)
-			{
+			if ($oAccount) {
 				$sLine = \str_replace('{imap:login}', Utils::UrlEncode($oAccount->IncLogin(), $bUrlEncode), $sLine);
 				$sLine = \str_replace('{imap:host}', Utils::UrlEncode($oAccount->DomainIncHost(), $bUrlEncode), $sLine);
 				$sLine = \str_replace('{imap:port}', Utils::UrlEncode($oAccount->DomainIncPort(), $bUrlEncode), $sLine);
@@ -403,22 +381,18 @@ class Actions
 			$aClear['/\{smtp:([^}]*)\}/i'] = 'smtp';
 		}
 
-		if (false !== \strpos($sLine, '{request:'))
-		{
-			if (false !== \strpos($sLine, '{request:ip}'))
-			{
+		if (false !== \strpos($sLine, '{request:')) {
+			if (false !== \strpos($sLine, '{request:ip}')) {
 				$sLine = \str_replace('{request:ip}', Utils::UrlEncode($this->Http()->GetClientIp(
 					$this->Config()->Get('labs', 'http_client_ip_check_proxy', false)), $bUrlEncode), $sLine);
 			}
 
-			if (false !== \strpos($sLine, '{request:domain}'))
-			{
+			if (false !== \strpos($sLine, '{request:domain}')) {
 				$sLine = \str_replace('{request:domain}',
 					Utils::UrlEncode($this->Http()->GetHost(false, true, true), $bUrlEncode), $sLine);
 			}
 
-			if (false !== \strpos($sLine, '{request:domain-clear}'))
-			{
+			if (false !== \strpos($sLine, '{request:domain-clear}')) {
 				$sLine = \str_replace('{request:domain-clear}',
 					Utils::UrlEncode(
 						\MailSo\Base\Utils::GetClearDomainName($this->Http()->GetHost(false, true, true)), $bUrlEncode), $sLine);
@@ -427,10 +401,8 @@ class Actions
 			$aClear['/\{request:([^}]*)\}/i'] = 'request';
 		}
 
-		if (false !== \strpos($sLine, '{user:'))
-		{
-			if (false !== \strpos($sLine, '{user:uid}'))
-			{
+		if (false !== \strpos($sLine, '{user:')) {
+			if (false !== \strpos($sLine, '{user:uid}')) {
 				$sLine = \str_replace('{user:uid}',
 					Utils::UrlEncode(\base_convert(\sprintf('%u',
 						\crc32(\md5(Utils::GetConnectionToken()))), 10, 32), $bUrlEncode),
@@ -438,22 +410,18 @@ class Actions
 				);
 			}
 
-			if (false !== \strpos($sLine, '{user:ip}'))
-			{
+			if (false !== \strpos($sLine, '{user:ip}')) {
 				$sLine = \str_replace('{user:ip}', Utils::UrlEncode($this->Http()->GetClientIp(
 					$this->Config()->Get('labs', 'http_client_ip_check_proxy', false)), $bUrlEncode), $sLine);
 			}
 
-			if (\preg_match('/\{user:(email|login|domain)\}/i', $sLine))
-			{
-				if (!$oAccount)
-				{
+			if (\preg_match('/\{user:(email|login|domain)\}/i', $sLine)) {
+				if (!$oAccount) {
 					$this->ParseQueryAuthString();
 					$oAccount = $this->getAccountFromToken(false);
 				}
 
-				if ($oAccount)
-				{
+				if ($oAccount) {
 					$sEmail = $oAccount->Email();
 
 					$sLine = \str_replace('{user:email}', Utils::UrlEncode($sEmail, $bUrlEncode), $sLine);
@@ -470,8 +438,7 @@ class Actions
 			$aClear['/\{user:([^}]*)\}/i'] = 'unknown';
 		}
 
-		if (false !== \strpos($sLine, '{labs:'))
-		{
+		if (false !== \strpos($sLine, '{labs:')) {
 			$sLine = \preg_replace_callback('/\{labs:rand:([1-9])\}/', function ($aMatch) {
 				return \rand(\pow(10, $aMatch[1] - 1), \pow(10, $aMatch[1]) - 1);
 			}, $sLine);
@@ -479,54 +446,49 @@ class Actions
 			$aClear['/\{labs:([^}]*)\}/'] = 'labs';
 		}
 
-		foreach ($aAdditionalParams as $sKey => $sValue)
-		{
+		foreach ($aAdditionalParams as $sKey => $sValue) {
 			$sLine = \str_replace($sKey, $sValue, $sLine);
 		}
 
-		foreach ($aClear as $sKey => $sValue)
-		{
+		foreach ($aClear as $sKey => $sValue) {
 			$sLine = \preg_replace($sKey, $sValue, $sLine);
 		}
 
 		return $sLine;
 	}
 
-	private function compileLogFileName(string $sFileName) : string
+	private function compileLogFileName(string $sFileName): string
 	{
 		$sFileName = \trim($sFileName);
 
-		if (0 !== \strlen($sFileName))
-		{
+		if (0 !== \strlen($sFileName)) {
 			$sFileName = $this->compileLogParams($sFileName);
 
 			$sFileName = \preg_replace('/[\/]+/', '/', \preg_replace('/[.]+/', '.', $sFileName));
 			$sFileName = \preg_replace('/[^a-zA-Z0-9@_+=\-\.\/!()\[\]]/', '', $sFileName);
 		}
 
-		if (0 === \strlen($sFileName))
-		{
+		if (0 === \strlen($sFileName)) {
 			$sFileName = 'rainloop-log.txt';
 		}
 
 		return $sFileName;
 	}
 
-	public function SetAuthLogoutToken() : void
+	public function SetAuthLogoutToken(): void
 	{
 		\header('X-RainLoop-Action: Logout');
 		Utils::SetCookie(self::AUTH_SPEC_LOGOUT_TOKEN_KEY, \md5($_SERVER['REQUEST_TIME_FLOAT']), 0);
 	}
 
-	public function SetAuthToken(Model\Account $oAccount) : void
+	public function SetAuthToken(Model\Account $oAccount): void
 	{
-		$sSpecAuthToken = '_'.$oAccount->GetAuthTokenQ();
+		$sSpecAuthToken = '_' . $oAccount->GetAuthTokenQ();
 
 		$this->SetSpecAuthToken($sSpecAuthToken);
 		Utils::SetCookie(self::AUTH_SPEC_TOKEN_KEY, $sSpecAuthToken, 0);
 
-		if ($oAccount->SignMe() && 0 < \strlen($oAccount->SignMeToken()))
-		{
+		if ($oAccount->SignMe() && 0 < \strlen($oAccount->SignMeToken())) {
 			Utils::SetCookie(self::AUTH_SIGN_ME_TOKEN_KEY,
 				Utils::EncodeKeyValuesQ(array(
 					'e' => $oAccount->Email(),
@@ -546,45 +508,42 @@ class Actions
 		}
 	}
 
-	public function GetSpecAuthTokenWithDeletion() : string
+	public function GetSpecAuthTokenWithDeletion(): string
 	{
 		$sResult = Utils::GetCookie(self::AUTH_SPEC_TOKEN_KEY, '');
-		if (0 < strlen($sResult))
-		{
+		if (0 < strlen($sResult)) {
 			Utils::ClearCookie(self::AUTH_SPEC_TOKEN_KEY);
 		}
 
 		return $sResult;
 	}
 
-	public function GetSpecAuthLogoutTokenWithDeletion() : string
+	public function GetSpecAuthLogoutTokenWithDeletion(): string
 	{
 		$sResult = Utils::GetCookie(self::AUTH_SPEC_LOGOUT_TOKEN_KEY, '');
-		if (0 < strlen($sResult))
-		{
+		if (0 < strlen($sResult)) {
 			Utils::ClearCookie(self::AUTH_SPEC_LOGOUT_TOKEN_KEY);
 		}
 
 		return $sResult;
 	}
 
-	public function GetSpecLogoutCustomMgsWithDeletion() : string
+	public function GetSpecLogoutCustomMgsWithDeletion(): string
 	{
 		$sResult = Utils::GetCookie(self::AUTH_SPEC_LOGOUT_CUSTOM_MSG_KEY, '');
-		if (0 < strlen($sResult))
-		{
+		if (0 < strlen($sResult)) {
 			Utils::ClearCookie(self::AUTH_SPEC_LOGOUT_CUSTOM_MSG_KEY);
 		}
 
 		return $sResult;
 	}
 
-	public function SetSpecLogoutCustomMgsWithDeletion(string $sMessage) : string
+	public function SetSpecLogoutCustomMgsWithDeletion(string $sMessage): string
 	{
 		Utils::SetCookie(self::AUTH_SPEC_LOGOUT_CUSTOM_MSG_KEY, $sMessage, 0);
 	}
 
-	private function getLocalAuthToken() : string
+	private function getLocalAuthToken(): string
 	{
 		$sToken = $this->GetSpecAuthToken();
 		return !empty($sToken) && '_' === \substr($sToken, 0, 1) ? \substr($sToken, 1) : '';
@@ -593,25 +552,23 @@ class Actions
 	/**
 	 * @throws \RainLoop\Exceptions\ClientException
 	 */
-	public function GetAccount(bool $bThrowExceptionOnFalse = false) : ?Model\Account
+	public function GetAccount(bool $bThrowExceptionOnFalse = false): ?Model\Account
 	{
 		return $this->getAccountFromToken($bThrowExceptionOnFalse);
 	}
 
-	public function Http() : \MailSo\Base\Http
+	public function Http(): \MailSo\Base\Http
 	{
-		if (null === $this->oHttp)
-		{
+		if (null === $this->oHttp) {
 			$this->oHttp = \MailSo\Base\Http::SingletonInstance();
 		}
 
 		return $this->oHttp;
 	}
 
-	public function MailClient() : \MailSo\Mail\MailClient
+	public function MailClient(): \MailSo\Mail\MailClient
 	{
-		if (null === $this->oMailClient)
-		{
+		if (null === $this->oMailClient) {
 			$this->oMailClient = new \MailSo\Mail\MailClient();
 			$this->oMailClient->SetLogger($this->Logger());
 		}
@@ -619,22 +576,17 @@ class Actions
 		return $this->oMailClient;
 	}
 
-	public function StorageProvider(bool $bLocal = false) : Providers\Storage
+	public function StorageProvider(bool $bLocal = false): Providers\Storage
 	{
-		if ($bLocal)
-		{
-			if (null === $this->oLocalStorageProvider)
-			{
+		if ($bLocal) {
+			if (null === $this->oLocalStorageProvider) {
 				$this->oLocalStorageProvider = new Providers\Storage(
 					$this->fabrica('storage-local'));
 			}
 
 			return $this->oLocalStorageProvider;
-		}
-		else
-		{
-			if (null === $this->oStorageProvider)
-			{
+		} else {
+			if (null === $this->oStorageProvider) {
 				$this->oStorageProvider = new Providers\Storage(
 					$this->fabrica('storage'));
 			}
@@ -643,31 +595,26 @@ class Actions
 		}
 	}
 
-	public function IdentitiesProvider() : Identities
-    {
-        if(null === $this->oIdentitiesProvider) {
-            $this->oIdentitiesProvider = new Providers\Identities($this->fabrica('identities'));
-        }
-
-        return $this->oIdentitiesProvider;
-    }
-
-	public function SettingsProvider(bool $bLocal = false) : Providers\Settings
+	public function IdentitiesProvider(): Identities
 	{
-		if ($bLocal)
-		{
-			if (null === $this->oLocalSettingsProvider)
-			{
+		if (null === $this->oIdentitiesProvider) {
+			$this->oIdentitiesProvider = new Providers\Identities($this->fabrica('identities'));
+		}
+
+		return $this->oIdentitiesProvider;
+	}
+
+	public function SettingsProvider(bool $bLocal = false): Providers\Settings
+	{
+		if ($bLocal) {
+			if (null === $this->oLocalSettingsProvider) {
 				$this->oLocalSettingsProvider = new Providers\Settings(
 					$this->fabrica('settings-local'));
 			}
 
 			return $this->oLocalSettingsProvider;
-		}
-		else
-		{
-			if (null === $this->oSettingsProvider)
-			{
+		} else {
+			if (null === $this->oSettingsProvider) {
 				$this->oSettingsProvider = new Providers\Settings(
 					$this->fabrica('settings'));
 			}
@@ -676,10 +623,9 @@ class Actions
 		}
 	}
 
-	public function FilesProvider() : Providers\Files
+	public function FilesProvider(): Providers\Files
 	{
-		if (null === $this->oFilesProvider)
-		{
+		if (null === $this->oFilesProvider) {
 			$this->oFilesProvider = new Providers\Files(
 				$this->fabrica('files'));
 		}
@@ -687,10 +633,9 @@ class Actions
 		return $this->oFilesProvider;
 	}
 
-	public function DomainProvider() : Providers\Domain
+	public function DomainProvider(): Providers\Domain
 	{
-		if (null === $this->oDomainProvider)
-		{
+		if (null === $this->oDomainProvider) {
 			$this->oDomainProvider = new Providers\Domain(
 				$this->fabrica('domain'), $this->Plugins());
 		}
@@ -698,10 +643,9 @@ class Actions
 		return $this->oDomainProvider;
 	}
 
-	public function SuggestionsProvider() : Providers\Suggestions
+	public function SuggestionsProvider(): Providers\Suggestions
 	{
-		if (null === $this->oSuggestionsProvider)
-		{
+		if (null === $this->oSuggestionsProvider) {
 			$this->oSuggestionsProvider = new Providers\Suggestions(
 				$this->fabrica('suggestions'));
 		}
@@ -709,15 +653,12 @@ class Actions
 		return $this->oSuggestionsProvider;
 	}
 
-	public function AddressBookProvider(?Model\Account $oAccount = null, bool $bForceEnable = false) : Providers\AddressBook
+	public function AddressBookProvider(?Model\Account $oAccount = null, bool $bForceEnable = false): Providers\AddressBook
 	{
-		if (null === $this->oAddressBookProvider)
-		{
+		if (null === $this->oAddressBookProvider) {
 			$oDriver = null;
-			if ($this->GetCapa(false, false, Enumerations\Capa::CONTACTS, $oAccount))
-			{
-				if ($this->Config()->Get('contacts', 'enable', false) || $bForceEnable)
-				{
+			if ($this->GetCapa(false, false, Enumerations\Capa::CONTACTS, $oAccount)) {
+				if ($this->Config()->Get('contacts', 'enable', false) || $bForceEnable) {
 					$oDriver = $this->fabrica('address-book', $oAccount);
 				}
 			}
@@ -729,32 +670,28 @@ class Actions
 		return $this->oAddressBookProvider;
 	}
 
-	public function Cacher(?Model\Account $oAccount = null, bool $bForceFile = false) : \MailSo\Cache\CacheClient
+	public function Cacher(?Model\Account $oAccount = null, bool $bForceFile = false): \MailSo\Cache\CacheClient
 	{
 		$sKey = '';
-		if ($oAccount)
-		{
+		if ($oAccount) {
 			$sKey = $oAccount->ParentEmailHelper();
 		}
 
 		$sIndexKey = empty($sKey) ? '_default_' : $sKey;
-		if ($bForceFile)
-		{
+		if ($bForceFile) {
 			$sIndexKey .= '/_files_';
 		}
 
-		if (!isset($this->aCachers[$sIndexKey]))
-		{
+		if (!isset($this->aCachers[$sIndexKey])) {
 			$this->aCachers[$sIndexKey] = new \MailSo\Cache\CacheClient();
 
 			$oDriver = null;
 			$sDriver = \strtoupper(\trim($this->Config()->Get('cache', 'fast_cache_driver', 'files')));
 
-			switch (true)
-			{
+			switch (true) {
 				default:
 				case $bForceFile:
-					$oDriver = new \MailSo\Cache\Drivers\File(APP_PRIVATE_DATA.'cache', $sKey);
+					$oDriver = new \MailSo\Cache\Drivers\File(APP_PRIVATE_DATA . 'cache', $sKey);
 					break;
 
 				case ('APC' === $sDriver || 'APCU' === $sDriver) &&
@@ -769,7 +706,7 @@ class Actions
 
 					$oDriver = new \MailSo\Cache\Drivers\Memcache(
 						$this->Config()->Get('labs', 'fast_cache_memcache_host', '127.0.0.1'),
-						(int) $this->Config()->Get('labs', 'fast_cache_memcache_port', 11211),
+						(int)$this->Config()->Get('labs', 'fast_cache_memcache_port', 11211),
 						43200,
 						$sKey
 					);
@@ -778,15 +715,14 @@ class Actions
 				case 'REDIS' === $sDriver && \class_exists('Predis\Client'):
 					$oDriver = new \MailSo\Cache\Drivers\Redis(
 						$this->Config()->Get('labs', 'fast_cache_redis_host', '127.0.0.1'),
-						(int) $this->Config()->Get('labs', 'fast_cache_redis_port', 6379),
+						(int)$this->Config()->Get('labs', 'fast_cache_redis_port', 6379),
 						43200,
 						$sKey
 					);
 					break;
 			}
 
-			if ($oDriver)
-			{
+			if ($oDriver) {
 				$this->aCachers[$sIndexKey]->SetDriver($oDriver);
 			}
 
@@ -796,10 +732,9 @@ class Actions
 		return $this->aCachers[$sIndexKey];
 	}
 
-	public function Plugins() : Plugins\Manager
+	public function Plugins(): Plugins\Manager
 	{
-		if (null === $this->oPlugins)
-		{
+		if (null === $this->oPlugins) {
 			$this->oPlugins = new Plugins\Manager($this);
 			$this->oPlugins->SetLogger($this->Logger());
 		}
@@ -807,44 +742,36 @@ class Actions
 		return $this->oPlugins;
 	}
 
-	public function Logger() : \MailSo\Log\Logger
+	public function Logger(): \MailSo\Log\Logger
 	{
-		if (null === $this->oLogger)
-		{
+		if (null === $this->oLogger) {
 			$this->oLogger = \MailSo\Log\Logger::SingletonInstance();
 
-			if (!!$this->Config()->Get('logs', 'enable', false))
-			{
-				$sSessionFilter = (string) $this->Config()->Get('logs', 'session_filter', '');
-				if (!empty($sSessionFilter))
-				{
+			if (!!$this->Config()->Get('logs', 'enable', false)) {
+				$sSessionFilter = (string)$this->Config()->Get('logs', 'session_filter', '');
+				if (!empty($sSessionFilter)) {
 					$aSessionParts = \explode(':', $sSessionFilter, 2);
 
 					if (empty($aSessionParts[0]) || empty($aSessionParts[1]) ||
-						(string) $aSessionParts[1] !== (string) Utils::GetCookie($aSessionParts[0], ''))
-					{
+						(string)$aSessionParts[1] !== (string)Utils::GetCookie($aSessionParts[0], '')) {
 						return $this->oLogger;
 					}
 				}
 
-				$sTimeOffset = (string) $this->Config()->Get('logs', 'time_offset', '0');
+				$sTimeOffset = (string)$this->Config()->Get('logs', 'time_offset', '0');
 
 				$this->oLogger->SetShowSecter(!$this->Config()->Get('logs', 'hide_passwords', true));
 
 				$sLogFileName = $this->Config()->Get('logs', 'filename', '');
 
 				$oDriver = null;
-				if ('syslog' === $sLogFileName)
-				{
+				if ('syslog' === $sLogFileName) {
 					$oDriver = new \MailSo\Log\Drivers\Syslog();
-				}
-				else
-				{
-					$sLogFileFullPath = \APP_PRIVATE_DATA.'logs/'.$this->compileLogFileName($sLogFileName);
+				} else {
+					$sLogFileFullPath = \APP_PRIVATE_DATA . 'logs/' . $this->compileLogFileName($sLogFileName);
 					$sLogFileDir = \dirname($sLogFileFullPath);
 
-					if (!is_dir($sLogFileDir))
-					{
+					if (!is_dir($sLogFileDir)) {
 						mkdir($sLogFileDir, 0755, true);
 					}
 
@@ -858,8 +785,7 @@ class Actions
 					->SetTimeOffset($sTimeOffset)
 				);
 
-				if (!$this->Config()->Get('debug', 'enable', false))
-				{
+				if (!$this->Config()->Get('debug', 'enable', false)) {
 					$this->oLogger->AddForbiddenType(\MailSo\Log\Enumerations\Type::TIME);
 				}
 
@@ -867,29 +793,29 @@ class Actions
 
 				$oHttp = $this->Http();
 
-				$this->oLogger->Write('[DATE:'.\MailSo\Log\Logger::DateHelper('d.m.y', $sTimeOffset).
-					(0 !== $sTimeOffset ? '][OFFSET:'.(0 < $sTimeOffset ? '+' : '-').
-						\str_pad((string) \abs($sTimeOffset), 2, '0', STR_PAD_LEFT) : '').
-					'][RL:'.APP_VERSION.'][PHP:'.PHP_VERSION.'][IP:'.
-					$oHttp->GetClientIp($this->Config()->Get('labs', 'http_client_ip_check_proxy', false)).'][PID:'.
-					(\MailSo\Base\Utils::FunctionExistsAndEnabled('getmypid') ? \getmypid() : 'unknown').']['.
-					$oHttp->GetServer('SERVER_SOFTWARE', '~').']['.
-					(\MailSo\Base\Utils::FunctionExistsAndEnabled('php_sapi_name') ? \php_sapi_name() : '~' ).']'
+				$this->oLogger->Write('[DATE:' . \MailSo\Log\Logger::DateHelper('d.m.y', $sTimeOffset) .
+					(0 !== $sTimeOffset ? '][OFFSET:' . (0 < $sTimeOffset ? '+' : '-') .
+						\str_pad((string)\abs($sTimeOffset), 2, '0', STR_PAD_LEFT) : '') .
+					'][RL:' . APP_VERSION . '][PHP:' . PHP_VERSION . '][IP:' .
+					$oHttp->GetClientIp($this->Config()->Get('labs', 'http_client_ip_check_proxy', false)) . '][PID:' .
+					(\MailSo\Base\Utils::FunctionExistsAndEnabled('getmypid') ? \getmypid() : 'unknown') . '][' .
+					$oHttp->GetServer('SERVER_SOFTWARE', '~') . '][' .
+					(\MailSo\Base\Utils::FunctionExistsAndEnabled('php_sapi_name') ? \php_sapi_name() : '~') . ']'
 				);
 
 				$sPdo = (\class_exists('PDO') ? \implode(',', \PDO::getAvailableDrivers()) : 'off');
 				$sPdo = empty($sPdo) ? '~' : $sPdo;
 
-				$this->oLogger->Write('['.
-					'Suhosin:'.(\extension_loaded('suhosin') || \ini_get('suhosin.get.max_value_length') ? 'on' : 'off').
-					'][APC:'.(\MailSo\Base\Utils::FunctionExistsAndEnabled('apc_fetch') ? 'on' : 'off').
-					'][MB:'.(\MailSo\Base\Utils::FunctionExistsAndEnabled('mb_convert_encoding') ? 'on' : 'off').
-					'][PDO:'.$sPdo.
-					'][Streams:'.\implode(',', \stream_get_transports()).
-				']');
+				$this->oLogger->Write('[' .
+					'Suhosin:' . (\extension_loaded('suhosin') || \ini_get('suhosin.get.max_value_length') ? 'on' : 'off') .
+					'][APC:' . (\MailSo\Base\Utils::FunctionExistsAndEnabled('apc_fetch') ? 'on' : 'off') .
+					'][MB:' . (\MailSo\Base\Utils::FunctionExistsAndEnabled('mb_convert_encoding') ? 'on' : 'off') .
+					'][PDO:' . $sPdo .
+					'][Streams:' . \implode(',', \stream_get_transports()) .
+					']');
 
 				$this->oLogger->Write(
-					'['.$oHttp->GetMethod().'] '.$oHttp->GetScheme().'://'.$oHttp->GetHost(false, false).$oHttp->GetServer('REQUEST_URI', ''),
+					'[' . $oHttp->GetMethod() . '] ' . $oHttp->GetScheme() . '://' . $oHttp->GetHost(false, false) . $oHttp->GetServer('REQUEST_URI', ''),
 					\MailSo\Log\Enumerations\Type::NOTE, 'REQUEST');
 			}
 		}
@@ -897,21 +823,18 @@ class Actions
 		return $this->oLogger;
 	}
 
-	public function LoggerAuth() : \MailSo\Log\Logger
+	public function LoggerAuth(): \MailSo\Log\Logger
 	{
-		if (null === $this->oLoggerAuth)
-		{
+		if (null === $this->oLoggerAuth) {
 			$this->oLoggerAuth = new \MailSo\Log\Logger(false);
 
-			if (!!$this->Config()->Get('logs', 'auth_logging', false))
-			{
-				$sAuthLogFileFullPath = \APP_PRIVATE_DATA.'logs/'.$this->compileLogFileName(
-					$this->Config()->Get('logs', 'auth_logging_filename', ''));
+			if (!!$this->Config()->Get('logs', 'auth_logging', false)) {
+				$sAuthLogFileFullPath = \APP_PRIVATE_DATA . 'logs/' . $this->compileLogFileName(
+						$this->Config()->Get('logs', 'auth_logging_filename', ''));
 
 				$sLogFileDir = \dirname($sAuthLogFileFullPath);
 
-				if (!is_dir($sLogFileDir))
-				{
+				if (!is_dir($sLogFileDir)) {
 					mkdir($sLogFileDir, 0755, true);
 				}
 
@@ -932,24 +855,21 @@ class Actions
 		return $this->oLoggerAuth;
 	}
 
-	public function LoggerAuthHelper(?Model\Account $oAccount = null, array $aAdditionalParams = array()) : void
+	public function LoggerAuthHelper(?Model\Account $oAccount = null, array $aAdditionalParams = array()): void
 	{
 		$sLine = $this->Config()->Get('logs', 'auth_logging_format', '');
-		if (!empty($sLine))
-		{
+		if (!empty($sLine)) {
 			$this->LoggerAuth()->Write($this->compileLogParams($sLine, $oAccount, false, $aAdditionalParams));
 		}
-		if ($this->Config()->Get('logs', 'auth_logging', false) && \openlog('snappymail', 0, \LOG_AUTHPRIV))
-		{
+		if ($this->Config()->Get('logs', 'auth_logging', false) && \openlog('snappymail', 0, \LOG_AUTHPRIV)) {
 			\syslog(\LOG_ERR, $this->compileLogParams('Auth failed: ip={request:ip} user={imap:login}', $oAccount, false, $aAdditionalParams));
 			\closelog();
 		}
 	}
 
-	public function SetMailtoRequest(string $sTo) : void
+	public function SetMailtoRequest(string $sTo): void
 	{
-		if (!empty($sTo))
-		{
+		if (!empty($sTo)) {
 			Utils::SetCookie(self::AUTH_MAILTO_TOKEN_KEY,
 				Utils::EncodeKeyValuesQ(array(
 					'Time' => \microtime(true),
@@ -959,31 +879,23 @@ class Actions
 		}
 	}
 
-	public function LoginProvide(string $sEmail, string $sLogin, string $sPassword, string $sSignMeToken = '', string $sClientCert = '', bool $bThrowProvideException = false) : ?Model\Account
+	public function LoginProvide(string $sEmail, string $sLogin, string $sPassword, string $sSignMeToken = '', string $sClientCert = '', bool $bThrowProvideException = false): ?Model\Account
 	{
 		$oAccount = null;
-		if (0 < \strlen($sEmail) && 0 < \strlen($sLogin) && 0 < \strlen($sPassword))
-		{
+		if (0 < \strlen($sEmail) && 0 < \strlen($sLogin) && 0 < \strlen($sPassword)) {
 			$oDomain = $this->DomainProvider()->Load(\MailSo\Base\Utils::GetDomainFromEmail($sEmail), true);
-			if ($oDomain)
-			{
-				if ($oDomain->ValidateWhiteList($sEmail, $sLogin))
-				{
+			if ($oDomain) {
+				if ($oDomain->ValidateWhiteList($sEmail, $sLogin)) {
 					$oAccount = new Model\Account($sEmail, $sLogin, $sPassword, $oDomain, $sSignMeToken, '', '', $sClientCert);
 					$this->Plugins()->RunHook('filter.acount', array($oAccount));
 
-					if ($bThrowProvideException && !$oAccount)
-					{
+					if ($bThrowProvideException && !$oAccount) {
 						throw new Exceptions\ClientException(Notifications::AuthError);
 					}
-				}
-				else if ($bThrowProvideException)
-				{
+				} else if ($bThrowProvideException) {
 					throw new Exceptions\ClientException(Notifications::AccountNotAllowed);
 				}
-			}
-			else if ($bThrowProvideException)
-			{
+			} else if ($bThrowProvideException) {
 				throw new Exceptions\ClientException(Notifications::DomainNotAllowed);
 			}
 		}
@@ -994,24 +906,21 @@ class Actions
 	/**
 	 * @throws \RainLoop\Exceptions\ClientException
 	 */
-	public function GetAccountFromCustomToken(string $sToken, bool $bThrowExceptionOnFalse = true, bool $bValidateShortToken = true, bool $bQ = false) : ?Model\Account
+	public function GetAccountFromCustomToken(string $sToken, bool $bThrowExceptionOnFalse = true, bool $bValidateShortToken = true, bool $bQ = false): ?Model\Account
 	{
 		$oResult = null;
-		if (!empty($sToken))
-		{
+		if (!empty($sToken)) {
 			$aAccountHash = $bQ ? Utils::DecodeKeyValuesQ($sToken) : Utils::DecodeKeyValues($sToken);
 			if (!empty($aAccountHash[0]) && 'token' === $aAccountHash[0] && // simple token validation
 				8 <= \count($aAccountHash) && // length checking
 				!empty($aAccountHash[7]) && // does short token exist
 				(!$bValidateShortToken || Utils::GetShortToken() === $aAccountHash[7] ||  // check short token if needed
 					(isset($aAccountHash[10]) && 0 < $aAccountHash[10] && \time() < $aAccountHash[10]))
-			)
-			{
+			) {
 				$oAccount = $this->LoginProvide($aAccountHash[1], $aAccountHash[2], $aAccountHash[3],
 					empty($aAccountHash[5]) ? '' : $aAccountHash[5], empty($aAccountHash[11]) ? '' : $aAccountHash[11], $bThrowExceptionOnFalse);
 
-				if ($oAccount)
-				{
+				if ($oAccount) {
 					if (!empty($aAccountHash[8]) && !empty($aAccountHash[9])) // init proxy user/password
 					{
 						$oAccount->SetProxyAuthUser($aAccountHash[8]);
@@ -1024,50 +933,41 @@ class Actions
 					$oAccount->SetParentEmail($aAccountHash[6]);
 					$oResult = $oAccount;
 				}
-			}
-			else if ($bThrowExceptionOnFalse)
-			{
+			} else if ($bThrowExceptionOnFalse) {
 				throw new Exceptions\ClientException(Notifications::AuthError);
 			}
 		}
 
-		if ($bThrowExceptionOnFalse && !$oResult)
-		{
+		if ($bThrowExceptionOnFalse && !$oResult) {
 			throw new Exceptions\ClientException(Notifications::AuthError);
 		}
 
 		return $oResult;
 	}
 
-	public function GetAccountFromSignMeToken() : ?Model\Account
+	public function GetAccountFromSignMeToken(): ?Model\Account
 	{
 		$oAccount = null;
 
 		$sSignMeToken = Utils::GetCookie(self::AUTH_SIGN_ME_TOKEN_KEY, '');
-		if (!empty($sSignMeToken))
-		{
+		if (!empty($sSignMeToken)) {
 			$aTokenData = Utils::DecodeKeyValuesQ($sSignMeToken);
-			if (!empty($aTokenData['e']) && !empty($aTokenData['t']))
-			{
+			if (!empty($aTokenData['e']) && !empty($aTokenData['t'])) {
 				$sTokenSettings = $this->StorageProvider()->Get($aTokenData['e'],
 					Providers\Storage\Enumerations\StorageType::CONFIG,
 					'sign_me'
 				);
 
-				if (!empty($sTokenSettings))
-				{
+				if (!empty($sTokenSettings)) {
 					$aSignMeData = Utils::DecodeKeyValuesQ($sTokenSettings);
 					if (!empty($aSignMeData['AuthToken']) &&
 						!empty($aSignMeData['SignMetToken']) &&
-						$aSignMeData['SignMetToken'] === $aTokenData['t'])
-					{
+						$aSignMeData['SignMetToken'] === $aTokenData['t']) {
 						$oAccount = $this->GetAccountFromCustomToken($aSignMeData['AuthToken'], false, false, true);
 					}
 				}
 			}
-		}
-		else
-		{
+		} else {
 			Utils::ClearCookie(self::AUTH_SIGN_ME_TOKEN_KEY);
 		}
 
@@ -1077,20 +977,18 @@ class Actions
 	/**
 	 * @throws \RainLoop\Exceptions\ClientException
 	 */
-	public function getAccountFromToken(bool $bThrowExceptionOnFalse = true) : ?Model\Account
+	public function getAccountFromToken(bool $bThrowExceptionOnFalse = true): ?Model\Account
 	{
 		return $this->GetAccountFromCustomToken($this->getLocalAuthToken(), $bThrowExceptionOnFalse, true, true);
 	}
 
-	public function AppDataSystem(bool $bAdmin = false, bool $bMobile = false, bool $bMobileDevice = false) : array
+	public function AppDataSystem(bool $bAdmin = false, bool $bMobile = false, bool $bMobileDevice = false): array
 	{
 		$oConfig = $this->Config();
 
 		$aAttachmentsActions = array();
-		if ($this->GetCapa(false, $bMobile, Enumerations\Capa::ATTACHMENTS_ACTIONS))
-		{
-			if (!!\class_exists('ZipArchive'))
-			{
+		if ($this->GetCapa(false, $bMobile, Enumerations\Capa::ATTACHMENTS_ACTIONS)) {
+			if (!!\class_exists('ZipArchive')) {
 				$aAttachmentsActions[] = 'zip';
 			}
 		}
@@ -1103,19 +1001,19 @@ class Actions
 			'webPath' => Utils::WebPath(),
 			'webVersionPath' => Utils::WebVersionPath(),
 			'token' => $oConfig->Get('security', 'csrf_protection', false) ? Utils::GetCsrfToken() : '',
-			'inIframe' => (bool) $oConfig->Get('labs', 'in_iframe', false),
-			'allowHtmlEditorSourceButton' => (bool) $oConfig->Get('labs', 'allow_html_editor_source_button', false),
-			'allowHtmlEditorBitiButtons' => (bool) $oConfig->Get('labs', 'allow_html_editor_biti_buttons', false),
-			'allowCtrlEnterOnCompose' => (bool) $oConfig->Get('labs', 'allow_ctrl_enter_on_compose', false),
+			'inIframe' => (bool)$oConfig->Get('labs', 'in_iframe', false),
+			'allowHtmlEditorSourceButton' => (bool)$oConfig->Get('labs', 'allow_html_editor_source_button', false),
+			'allowHtmlEditorBitiButtons' => (bool)$oConfig->Get('labs', 'allow_html_editor_biti_buttons', false),
+			'allowCtrlEnterOnCompose' => (bool)$oConfig->Get('labs', 'allow_ctrl_enter_on_compose', false),
 			'forgotPasswordLinkUrl' => \trim($oConfig->Get('login', 'forgot_password_link_url', '')),
 			'registrationLinkUrl' => \trim($oConfig->Get('login', 'registration_link_url', '')),
-			'hideSubmitButton' => (bool) $oConfig->Get('login', 'hide_submit_button', true),
-			'useImapThread' => (bool) $oConfig->Get('labs', 'use_imap_thread', false),
-			'useImapSubscribe' => (bool) $oConfig->Get('labs', 'use_imap_list_subscribe', true),
-			'allowAppendMessage' => (bool) $oConfig->Get('labs', 'allow_message_append', false),
-			'materialDesign' => (bool) $oConfig->Get('labs', 'use_material_design', true),
-			'folderSpecLimit' => (int) $oConfig->Get('labs', 'folders_spec_limit', 50),
-			'faviconStatus' => (bool) $oConfig->Get('labs', 'favicon_status', true),
+			'hideSubmitButton' => (bool)$oConfig->Get('login', 'hide_submit_button', true),
+			'useImapThread' => (bool)$oConfig->Get('labs', 'use_imap_thread', false),
+			'useImapSubscribe' => (bool)$oConfig->Get('labs', 'use_imap_list_subscribe', true),
+			'allowAppendMessage' => (bool)$oConfig->Get('labs', 'allow_message_append', false),
+			'materialDesign' => (bool)$oConfig->Get('labs', 'use_material_design', true),
+			'folderSpecLimit' => (int)$oConfig->Get('labs', 'folders_spec_limit', 50),
+			'faviconStatus' => (bool)$oConfig->Get('labs', 'favicon_status', true),
 			'listPermanentFiltered' => '' !== \trim(Api::Config()->Get('labs', 'imap_message_list_permanent_filter', '')),
 			'themes' => $this->GetThemes($bMobile, false),
 			'languages' => $this->GetLanguages(false),
@@ -1124,24 +1022,23 @@ class Actions
 		), $bAdmin ? array(
 			'adminHostUse' => '' !== $oConfig->Get('security', 'admin_panel_host', ''),
 			'adminPath' => \strtolower($oConfig->Get('security', 'admin_panel_key', 'admin')),
-			'allowAdminPanel' => (bool) $oConfig->Get('security', 'allow_admin_panel', true),
+			'allowAdminPanel' => (bool)$oConfig->Get('security', 'allow_admin_panel', true),
 		) : array());
 	}
 
-	public function AppData(bool $bAdmin, bool $bMobile = false, bool $bMobileDevice = false, string $sAuthAccountHash = '') : array
+	public function AppData(bool $bAdmin, bool $bMobile = false, bool $bMobileDevice = false, string $sAuthAccountHash = ''): array
 	{
-		if (0 < \strlen($sAuthAccountHash) && \preg_match('/[^_\-\.a-zA-Z0-9]/', $sAuthAccountHash))
-		{
+		if (0 < \strlen($sAuthAccountHash) && \preg_match('/[^_\-\.a-zA-Z0-9]/', $sAuthAccountHash)) {
 			$sAuthAccountHash = '';
 		}
 
 		$oAccount = null;
 		$oConfig = $this->Config();
 
-/*
-required by Index.html and rl.js:
-NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink AuthAccountHash
-*/
+		/*
+		required by Index.html and rl.js:
+		NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink AuthAccountHash
+		*/
 
 		$aResult = array(
 			'Auth' => false,
@@ -1166,42 +1063,39 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 			'IncludeCss' => '',
 			'IncludeBackground' => '',
 			'LoginDefaultDomain' => $oConfig->Get('login', 'default_domain', ''),
-			'DetermineUserLanguage' => (bool) $oConfig->Get('login', 'determine_user_language', true),
-			'DetermineUserDomain' => (bool) $oConfig->Get('login', 'determine_user_domain', false),
-			'UseLoginWelcomePage' => (bool) $oConfig->Get('login', 'welcome_page', false),
+			'DetermineUserLanguage' => (bool)$oConfig->Get('login', 'determine_user_language', true),
+			'DetermineUserDomain' => (bool)$oConfig->Get('login', 'determine_user_domain', false),
+			'UseLoginWelcomePage' => (bool)$oConfig->Get('login', 'welcome_page', false),
 			'StartupUrl' => \trim(\ltrim(\trim($oConfig->Get('labs', 'startup_url', '')), '#/')),
-			'SieveAllowFileintoInbox' => (bool) $oConfig->Get('labs', 'sieve_allow_fileinto_inbox', false),
+			'SieveAllowFileintoInbox' => (bool)$oConfig->Get('labs', 'sieve_allow_fileinto_inbox', false),
 			'ContactsIsAllowed' => false,
 			'RequireTwoFactor' => false,
 			'Admin' => array(),
 			'Capa' => array(),
 			'Plugins' => array(),
 			'System' => $this->AppDataSystem($bAdmin, $bMobile, $bMobileDevice)
-/*
-			'LoginLogo' => $oConfig->Get('branding', 'login_logo', ''),
-			'LoginBackground' => $oConfig->Get('branding', 'login_background', ''),
-			'LoginCss' => $oConfig->Get('branding', 'login_css', ''),
-			'LoginDescription' => $oConfig->Get('branding', 'login_desc', ''),
-			'UserLogo' => $oConfig->Get('branding', 'user_logo', ''),
-			'UserLogoTitle' => $oConfig->Get('branding', 'user_logo_title', ''),
-			'UserLogoMessage' => $oConfig->Get('branding', 'user_logo_message', ''),
-			'UserIframeMessage' => $oConfig->Get('branding', 'user_iframe_message', ''),
-			'UserCss' => $oConfig->Get('branding', 'user_css', ''),
-*/
+			/*
+						'LoginLogo' => $oConfig->Get('branding', 'login_logo', ''),
+						'LoginBackground' => $oConfig->Get('branding', 'login_background', ''),
+						'LoginCss' => $oConfig->Get('branding', 'login_css', ''),
+						'LoginDescription' => $oConfig->Get('branding', 'login_desc', ''),
+						'UserLogo' => $oConfig->Get('branding', 'user_logo', ''),
+						'UserLogoTitle' => $oConfig->Get('branding', 'user_logo_title', ''),
+						'UserLogoMessage' => $oConfig->Get('branding', 'user_logo_message', ''),
+						'UserIframeMessage' => $oConfig->Get('branding', 'user_iframe_message', ''),
+						'UserCss' => $oConfig->Get('branding', 'user_css', ''),
+			*/
 		);
 
-		if (0 < \strlen($sAuthAccountHash))
-		{
+		if (0 < \strlen($sAuthAccountHash)) {
 			$aResult['AuthAccountHash'] = $sAuthAccountHash;
 		}
 
 		$oSettings = null;
 
-		if (!$bAdmin)
-		{
+		if (!$bAdmin) {
 			$oAccount = $this->getAccountFromToken(false);
-			if ($oAccount)
-			{
+			if ($oAccount) {
 				$aResult['IncludeCss'] = $aResult['UserCss'];
 
 				$oAddressBookProvider = $this->AddressBookProvider($oAccount);
@@ -1213,19 +1107,17 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 				$aResult['AccountHash'] = $oAccount->Hash();
 				$aResult['AccountSignMe'] = $oAccount->SignMe();
 				$aResult['ContactsIsAllowed'] = $oAddressBookProvider->IsActive();
-				$aResult['ContactsSyncIsAllowed'] = (bool) $oConfig->Get('contacts', 'allow_sync', false);
-				$aResult['ContactsSyncInterval'] = (int) $oConfig->Get('contacts', 'sync_interval', 20);
+				$aResult['ContactsSyncIsAllowed'] = (bool)$oConfig->Get('contacts', 'allow_sync', false);
+				$aResult['ContactsSyncInterval'] = (int)$oConfig->Get('contacts', 'sync_interval', 20);
 
 				$aResult['EnableContactsSync'] = false;
 				$aResult['ContactsSyncUrl'] = '';
 				$aResult['ContactsSyncUser'] = '';
 				$aResult['ContactsSyncPassword'] = '';
 
-				if ($aResult['ContactsIsAllowed'] && $aResult['ContactsSyncIsAllowed'])
-				{
+				if ($aResult['ContactsIsAllowed'] && $aResult['ContactsSyncIsAllowed']) {
 					$mData = $this->getContactsSyncData($oAccount);
-					if (\is_array($mData))
-					{
+					if (\is_array($mData)) {
 						$aResult['EnableContactsSync'] = isset($mData['Enable']) ? !!$mData['Enable'] : false;
 						$aResult['ContactsSyncUrl'] = isset($mData['Url']) ? \trim($mData['Url']) : '';
 						$aResult['ContactsSyncUser'] = isset($mData['User']) ? \trim($mData['User']) : '';
@@ -1233,17 +1125,14 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 					}
 				}
 
-				if ($aResult['AccountSignMe'])
-				{
+				if ($aResult['AccountSignMe']) {
 					$sToken = Utils::GetCookie(self::AUTH_MAILTO_TOKEN_KEY, null);
-					if (null !== $sToken)
-					{
+					if (null !== $sToken) {
 						Utils::ClearCookie(self::AUTH_MAILTO_TOKEN_KEY);
 
 						$mMailToData = Utils::DecodeKeyValuesQ($sToken);
 						if (!empty($mMailToData['MailTo']) &&
-							'MailTo' === $mMailToData['MailTo'] && !empty($mMailToData['To']))
-						{
+							'MailTo' === $mMailToData['MailTo'] && !empty($mMailToData['To'])) {
 							$aResult['MailToEmail'] = $mMailToData['To'];
 						}
 					}
@@ -1251,18 +1140,14 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 
 				$oSettings = $this->SettingsProvider()->Load($oAccount);
 
-				if (!empty($aResult['StartupUrl']))
-				{
+				if (!empty($aResult['StartupUrl'])) {
 					$aResult['StartupUrl'] = $this->compileLogParams($aResult['StartupUrl'], $oAccount, true);
 				}
 
-				if (!empty($aResult['UserIframeMessage']))
-				{
+				if (!empty($aResult['UserIframeMessage'])) {
 					$aResult['UserIframeMessage'] = $this->compileLogParams($aResult['UserIframeMessage'], $oAccount, true);
 				}
-			}
-			else
-			{
+			} else {
 				$aResult['IncludeBackground'] = $aResult['LoginBackground'];
 				$aResult['IncludeCss'] = $aResult['LoginCss'];
 
@@ -1271,20 +1156,17 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 
 				$aResult['StartupUrl'] = '';
 
-				if (empty($aResult['AdditionalLoginError']))
-				{
+				if (empty($aResult['AdditionalLoginError'])) {
 					$aResult['AdditionalLoginError'] = $this->GetSpecLogoutCustomMgsWithDeletion();
 				}
 			}
 
 			$aResult['Capa'] = $this->Capa(false, $bMobile, $oAccount);
 
-			if ($aResult['Auth'] && !$aResult['RequireTwoFactor'])
-			{
+			if ($aResult['Auth'] && !$aResult['RequireTwoFactor']) {
 				if ($this->GetCapa(false, $bMobile, Enumerations\Capa::TWO_FACTOR, $oAccount) &&
 					$this->GetCapa(false, $bMobile, Enumerations\Capa::TWO_FACTOR_FORCE, $oAccount) &&
-					$this->TwoFactorAuthProvider()->IsActive())
-				{
+					$this->TwoFactorAuthProvider()->IsActive()) {
 					$aData = $this->getTwoFactorInfo($oAccount, true);
 
 					$aResult['RequireTwoFactor'] = !$aData ||
@@ -1292,31 +1174,28 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 						!($aData['IsSet'] && $aData['Enable']);
 				}
 			}
-		}
-		else
-		{
+		} else {
 			$aResult['Auth'] = $this->IsAdminLoggined(false);
-			if ($aResult['Auth'])
-			{
+			if ($aResult['Auth']) {
 				$aResult['AdminDomain'] = APP_SITE;
-				$aResult['AdminLogin'] = (string) $oConfig->Get('security', 'admin_login', '');
-				$aResult['UseTokenProtection'] = (bool) $oConfig->Get('security', 'csrf_protection', true);
-				$aResult['EnabledPlugins'] = (bool) $oConfig->Get('plugins', 'enable', false);
+				$aResult['AdminLogin'] = (string)$oConfig->Get('security', 'admin_login', '');
+				$aResult['UseTokenProtection'] = (bool)$oConfig->Get('security', 'csrf_protection', true);
+				$aResult['EnabledPlugins'] = (bool)$oConfig->Get('plugins', 'enable', false);
 
-				$aResult['VerifySslCertificate'] = (bool) $oConfig->Get('ssl', 'verify_certificate', false);
-				$aResult['AllowSelfSigned'] = (bool) $oConfig->Get('ssl', 'allow_self_signed', true);
+				$aResult['VerifySslCertificate'] = (bool)$oConfig->Get('ssl', 'verify_certificate', false);
+				$aResult['AllowSelfSigned'] = (bool)$oConfig->Get('ssl', 'allow_self_signed', true);
 
 				$aResult['supportedPdoDrivers'] = \class_exists('PDO') ? \PDO::getAvailableDrivers() : [];
 
-				$aResult['ContactsEnable'] = (bool) $oConfig->Get('contacts', 'enable', false);
-				$aResult['ContactsSync'] = (bool) $oConfig->Get('contacts', 'allow_sync', false);
-				$aResult['ContactsPdoType'] = (string) $this->ValidateContactPdoType(\trim($this->Config()->Get('contacts', 'type', 'sqlite')));
-				$aResult['ContactsPdoDsn'] = (string) $oConfig->Get('contacts', 'pdo_dsn', '');
-				$aResult['ContactsPdoType'] = (string) $oConfig->Get('contacts', 'type', '');
-				$aResult['ContactsPdoUser'] = (string) $oConfig->Get('contacts', 'pdo_user', '');
-				$aResult['ContactsPdoPassword'] = (string) APP_DUMMY;
+				$aResult['ContactsEnable'] = (bool)$oConfig->Get('contacts', 'enable', false);
+				$aResult['ContactsSync'] = (bool)$oConfig->Get('contacts', 'allow_sync', false);
+				$aResult['ContactsPdoType'] = (string)$this->ValidateContactPdoType(\trim($this->Config()->Get('contacts', 'type', 'sqlite')));
+				$aResult['ContactsPdoDsn'] = (string)$oConfig->Get('contacts', 'pdo_dsn', '');
+				$aResult['ContactsPdoType'] = (string)$oConfig->Get('contacts', 'type', '');
+				$aResult['ContactsPdoUser'] = (string)$oConfig->Get('contacts', 'pdo_user', '');
+				$aResult['ContactsPdoPassword'] = (string)APP_DUMMY;
 
-				$aResult['WeakPassword'] = (bool) $oConfig->ValidatePassword('12345');
+				$aResult['WeakPassword'] = (bool)$oConfig->ValidatePassword('12345');
 
 				$aResult['PhpUploadSizes'] = array(
 					'upload_max_filesize' => \ini_get('upload_max_filesize'),
@@ -1327,85 +1206,78 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 			$aResult['Capa'] = $this->Capa(true, $bMobile);
 		}
 
-		$aResult['ProjectHash'] = \md5($aResult['AccountHash'].APP_VERSION.$this->Plugins()->Hash());
+		$aResult['ProjectHash'] = \md5($aResult['AccountHash'] . APP_VERSION . $this->Plugins()->Hash());
 
 		$sLanguage = $oConfig->Get('webmail', 'language', 'en');
 		$sLanguageAdmin = $oConfig->Get('webmail', 'language_admin', 'en');
 		$sTheme = $oConfig->Get('webmail', 'theme', 'Default');
 
-		$aResult['NewMoveToFolder'] = (bool) $oConfig->Get('interface', 'new_move_to_folder_button', true);
-		$aResult['AllowLanguagesOnSettings'] = (bool) $oConfig->Get('webmail', 'allow_languages_on_settings', true);
-		$aResult['AllowLanguagesOnLogin'] = (bool) $oConfig->Get('login', 'allow_languages_on_login', true);
-		$aResult['AttachmentLimit'] = ((int) $oConfig->Get('webmail', 'attachment_size_limit', 10)) * 1024 * 1024;
-		$aResult['SignMe'] = (string) $oConfig->Get('login', 'sign_me_auto', Enumerations\SignMeType::DEFAILT_OFF);
-		$aResult['UseLocalProxyForExternalImages'] = (bool) $oConfig->Get('labs', 'use_local_proxy_for_external_images', false);
+		$aResult['NewMoveToFolder'] = (bool)$oConfig->Get('interface', 'new_move_to_folder_button', true);
+		$aResult['AllowLanguagesOnSettings'] = (bool)$oConfig->Get('webmail', 'allow_languages_on_settings', true);
+		$aResult['AllowLanguagesOnLogin'] = (bool)$oConfig->Get('login', 'allow_languages_on_login', true);
+		$aResult['AttachmentLimit'] = ((int)$oConfig->Get('webmail', 'attachment_size_limit', 10)) * 1024 * 1024;
+		$aResult['SignMe'] = (string)$oConfig->Get('login', 'sign_me_auto', Enumerations\SignMeType::DEFAILT_OFF);
+		$aResult['UseLocalProxyForExternalImages'] = (bool)$oConfig->Get('labs', 'use_local_proxy_for_external_images', false);
 
 		// user
-		$aResult['ShowImages'] = (bool) $oConfig->Get('defaults', 'show_images', false);
-		$aResult['MPP'] = (int) $oConfig->Get('webmail', 'messages_per_page', 25);
+		$aResult['ShowImages'] = (bool)$oConfig->Get('defaults', 'show_images', false);
+		$aResult['MPP'] = (int)$oConfig->Get('webmail', 'messages_per_page', 25);
 		$aResult['SoundNotification'] = false;
 		$aResult['DesktopNotifications'] = false;
-		$aResult['Layout'] = (int) $oConfig->Get('defaults', 'view_layout', Enumerations\Layout::SIDE_PREVIEW);
-		$aResult['EditorDefaultType'] = (string) $oConfig->Get('defaults', 'view_editor_type', '');
-		$aResult['UseCheckboxesInList'] = (bool) $oConfig->Get('defaults', 'view_use_checkboxes', true);
-		$aResult['AutoLogout'] = (int) $oConfig->Get('defaults', 'autologout', 30);
-		$aResult['UseThreads'] = (bool) $oConfig->Get('defaults', 'mail_use_threads', false);
-		$aResult['AllowDraftAutosave'] = (bool) $oConfig->Get('defaults', 'allow_draft_autosave', true);
-		$aResult['ReplySameFolder'] = (bool) $oConfig->Get('defaults', 'mail_reply_same_folder', false);
-		$aResult['ContactsAutosave'] = (bool) $oConfig->Get('defaults', 'contacts_autosave', true);
+		$aResult['Layout'] = (int)$oConfig->Get('defaults', 'view_layout', Enumerations\Layout::SIDE_PREVIEW);
+		$aResult['EditorDefaultType'] = (string)$oConfig->Get('defaults', 'view_editor_type', '');
+		$aResult['UseCheckboxesInList'] = (bool)$oConfig->Get('defaults', 'view_use_checkboxes', true);
+		$aResult['AutoLogout'] = (int)$oConfig->Get('defaults', 'autologout', 30);
+		$aResult['UseThreads'] = (bool)$oConfig->Get('defaults', 'mail_use_threads', false);
+		$aResult['AllowDraftAutosave'] = (bool)$oConfig->Get('defaults', 'allow_draft_autosave', true);
+		$aResult['ReplySameFolder'] = (bool)$oConfig->Get('defaults', 'mail_reply_same_folder', false);
+		$aResult['ContactsAutosave'] = (bool)$oConfig->Get('defaults', 'contacts_autosave', true);
 		$aResult['EnableTwoFactor'] = false;
 		$aResult['ParentEmail'] = '';
 		$aResult['InterfaceAnimation'] = true;
 		$aResult['UserBackgroundName'] = '';
 		$aResult['UserBackgroundHash'] = '';
 
-		if (!$bAdmin && $oAccount)
-		{
+		if (!$bAdmin && $oAccount) {
 			$aResult['ParentEmail'] = $oAccount->ParentEmail();
 
 			$oSettingsLocal = $this->SettingsProvider(true)->Load($oAccount);
 
-			if ($oSettingsLocal instanceof Settings)
-			{
+			if ($oSettingsLocal instanceof Settings) {
 //				if ($this->GetCapa(false, $bMobile, Enumerations\Capa::FOLDERS, $oAccount))
 
-				$aResult['SentFolder'] = (string) $oSettingsLocal->GetConf('SentFolder', '');
-				$aResult['DraftFolder'] = (string) $oSettingsLocal->GetConf('DraftFolder', '');
-				$aResult['SpamFolder'] = (string) $oSettingsLocal->GetConf('SpamFolder', '');
-				$aResult['TrashFolder'] = (string) $oSettingsLocal->GetConf('TrashFolder', '');
-				$aResult['ArchiveFolder'] = (string) $oSettingsLocal->GetConf('ArchiveFolder', '');
-				$aResult['NullFolder'] = (string) $oSettingsLocal->GetConf('NullFolder', '');
+				$aResult['SentFolder'] = (string)$oSettingsLocal->GetConf('SentFolder', '');
+				$aResult['DraftFolder'] = (string)$oSettingsLocal->GetConf('DraftFolder', '');
+				$aResult['SpamFolder'] = (string)$oSettingsLocal->GetConf('SpamFolder', '');
+				$aResult['TrashFolder'] = (string)$oSettingsLocal->GetConf('TrashFolder', '');
+				$aResult['ArchiveFolder'] = (string)$oSettingsLocal->GetConf('ArchiveFolder', '');
+				$aResult['NullFolder'] = (string)$oSettingsLocal->GetConf('NullFolder', '');
 			}
 
-			if ($this->GetCapa(false, $bMobile, Enumerations\Capa::SETTINGS, $oAccount))
-			{
-				if ($oSettings instanceof Settings)
-				{
-					if ($oConfig->Get('webmail', 'allow_languages_on_settings', true))
-					{
-						$sLanguage = (string) $oSettings->GetConf('Language', $sLanguage);
+			if ($this->GetCapa(false, $bMobile, Enumerations\Capa::SETTINGS, $oAccount)) {
+				if ($oSettings instanceof Settings) {
+					if ($oConfig->Get('webmail', 'allow_languages_on_settings', true)) {
+						$sLanguage = (string)$oSettings->GetConf('Language', $sLanguage);
 					}
 
-					$aResult['EditorDefaultType'] = (string) $oSettings->GetConf('EditorDefaultType', $aResult['EditorDefaultType']);
-					$aResult['ShowImages'] = (bool) $oSettings->GetConf('ShowImages', $aResult['ShowImages']);
-					$aResult['ContactsAutosave'] = (bool) $oSettings->GetConf('ContactsAutosave', $aResult['ContactsAutosave']);
-					$aResult['MPP'] = (int) $oSettings->GetConf('MPP', $aResult['MPP']);
-					$aResult['SoundNotification'] = (bool) $oSettings->GetConf('SoundNotification', $aResult['SoundNotification']);
-					$aResult['DesktopNotifications'] = (bool) $oSettings->GetConf('DesktopNotifications', $aResult['DesktopNotifications']);
-					$aResult['UseCheckboxesInList'] = (bool) $oSettings->GetConf('UseCheckboxesInList', $aResult['UseCheckboxesInList']);
-					$aResult['AllowDraftAutosave'] = (bool) $oSettings->GetConf('AllowDraftAutosave', $aResult['AllowDraftAutosave']);
-					$aResult['AutoLogout'] = (int) $oSettings->GetConf('AutoLogout', $aResult['AutoLogout']);
-					$aResult['Layout'] = (int) $oSettings->GetConf('Layout', $aResult['Layout']);
+					$aResult['EditorDefaultType'] = (string)$oSettings->GetConf('EditorDefaultType', $aResult['EditorDefaultType']);
+					$aResult['ShowImages'] = (bool)$oSettings->GetConf('ShowImages', $aResult['ShowImages']);
+					$aResult['ContactsAutosave'] = (bool)$oSettings->GetConf('ContactsAutosave', $aResult['ContactsAutosave']);
+					$aResult['MPP'] = (int)$oSettings->GetConf('MPP', $aResult['MPP']);
+					$aResult['SoundNotification'] = (bool)$oSettings->GetConf('SoundNotification', $aResult['SoundNotification']);
+					$aResult['DesktopNotifications'] = (bool)$oSettings->GetConf('DesktopNotifications', $aResult['DesktopNotifications']);
+					$aResult['UseCheckboxesInList'] = (bool)$oSettings->GetConf('UseCheckboxesInList', $aResult['UseCheckboxesInList']);
+					$aResult['AllowDraftAutosave'] = (bool)$oSettings->GetConf('AllowDraftAutosave', $aResult['AllowDraftAutosave']);
+					$aResult['AutoLogout'] = (int)$oSettings->GetConf('AutoLogout', $aResult['AutoLogout']);
+					$aResult['Layout'] = (int)$oSettings->GetConf('Layout', $aResult['Layout']);
 
-					if (!$this->GetCapa(false, $bMobile, Enumerations\Capa::AUTOLOGOUT, $oAccount))
-					{
+					if (!$this->GetCapa(false, $bMobile, Enumerations\Capa::AUTOLOGOUT, $oAccount)) {
 						$aResult['AutoLogout'] = 0;
 					}
 
-					if ($this->GetCapa(false, $bMobile, Enumerations\Capa::USER_BACKGROUND, $oAccount))
-					{
-						$aResult['UserBackgroundName'] = (string) $oSettings->GetConf('UserBackgroundName', $aResult['UserBackgroundName']);
-						$aResult['UserBackgroundHash'] = (string) $oSettings->GetConf('UserBackgroundHash', $aResult['UserBackgroundHash']);
+					if ($this->GetCapa(false, $bMobile, Enumerations\Capa::USER_BACKGROUND, $oAccount)) {
+						$aResult['UserBackgroundName'] = (string)$oSettings->GetConf('UserBackgroundName', $aResult['UserBackgroundName']);
+						$aResult['UserBackgroundHash'] = (string)$oSettings->GetConf('UserBackgroundHash', $aResult['UserBackgroundHash']);
 //						if (!empty($aResult['UserBackgroundName']) && !empty($aResult['UserBackgroundHash']))
 //						{
 //							$aResult['IncludeBackground'] = './?/Raw/&q[]=/{{USER}}/UserBackground/&q[]=/'.
@@ -1413,29 +1285,24 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 //						}
 					}
 
-					$aResult['EnableTwoFactor'] = (bool) $oSettings->GetConf('EnableTwoFactor', $aResult['EnableTwoFactor']);
+					$aResult['EnableTwoFactor'] = (bool)$oSettings->GetConf('EnableTwoFactor', $aResult['EnableTwoFactor']);
 				}
 
-				if ($oSettingsLocal instanceof Settings)
-				{
-					$aResult['UseThreads'] = (bool) $oSettingsLocal->GetConf('UseThreads', $aResult['UseThreads']);
-					$aResult['ReplySameFolder'] = (bool) $oSettingsLocal->GetConf('ReplySameFolder', $aResult['ReplySameFolder']);
+				if ($oSettingsLocal instanceof Settings) {
+					$aResult['UseThreads'] = (bool)$oSettingsLocal->GetConf('UseThreads', $aResult['UseThreads']);
+					$aResult['ReplySameFolder'] = (bool)$oSettingsLocal->GetConf('ReplySameFolder', $aResult['ReplySameFolder']);
 
-					if ($this->GetCapa(false, $bMobile, Enumerations\Capa::THEMES, $oAccount))
-					{
-						$sTheme = (string) $oSettingsLocal->GetConf('Theme', $sTheme);
+					if ($this->GetCapa(false, $bMobile, Enumerations\Capa::THEMES, $oAccount)) {
+						$sTheme = (string)$oSettingsLocal->GetConf('Theme', $sTheme);
 					}
 				}
 			}
 		}
 
-		if (!$aResult['Auth'])
-		{
-			if (!$bAdmin)
-			{
+		if (!$aResult['Auth']) {
+			if (!$bAdmin) {
 				if ($oConfig->Get('login', 'allow_languages_on_login', true) &&
-					$oConfig->Get('login', 'determine_user_language', true))
-				{
+					$oConfig->Get('login', 'determine_user_language', true)) {
 					$sLanguage = $this->ValidateLanguage(
 						$this->detectUserLanguage($bAdmin), $sLanguage, false);
 				}
@@ -1457,23 +1324,22 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		$aResult['UserLanguageAdmin'] = $this->ValidateLanguage($aResult['UserLanguageRaw'], '', true, true);
 
 		$aResult['PluginsLink'] = '';
-		if (0 < $this->Plugins()->Count() && $this->Plugins()->HaveJs($bAdmin))
-		{
-			$aResult['PluginsLink'] = './?/Plugins/0/'.($bAdmin ? 'Admin' : 'User').'/'.$sStaticCache.'/';
+		if (0 < $this->Plugins()->Count() && $this->Plugins()->HaveJs($bAdmin)) {
+			$aResult['PluginsLink'] = './?/Plugins/0/' . ($bAdmin ? 'Admin' : 'User') . '/' . $sStaticCache . '/';
 		}
 
-		$aResult['LangLink'] = './?/Lang/0/'.($bAdmin ? 'Admin' : 'App').'/'.
-			($bAdmin ? $aResult['LanguageAdmin'] : $aResult['Language']).'/'.$sStaticCache.'/';
+		$aResult['LangLink'] = './?/Lang/0/' . ($bAdmin ? 'Admin' : 'App') . '/' .
+			($bAdmin ? $aResult['LanguageAdmin'] : $aResult['Language']) . '/' . $sStaticCache . '/';
 
 		// $aResult['TemplatesLink'] = './?/Templates/0/'.($bAdmin ? 'Admin' : 'App').'/'.$sStaticCache.'/';
-		$aResult['TemplatesLink'] = './?/Templates/0/'.($bAdmin ? 'Admin' : 'App').'/'.$sStaticCache.'/';
+		$aResult['TemplatesLink'] = './?/Templates/0/' . ($bAdmin ? 'Admin' : 'App') . '/' . $sStaticCache . '/';
 
 		$bAppJsDebug = !!$this->Config()->Get('labs', 'use_app_debug_js', false);
 
-		$aResult['StaticLibJsLink'] = $this->StaticPath('js/'.($bAppJsDebug ? '' : 'min/').
-			'libs'.($bAppJsDebug ? '' : '.min').'.js');
-		$aResult['StaticAppJsLink'] = $this->StaticPath('js/'.($bAppJsDebug ? '' : 'min/').
-			($bAdmin ? 'admin' : 'app').($bAppJsDebug ? '' : '.min').'.js');
+		$aResult['StaticLibJsLink'] = $this->StaticPath('js/' . ($bAppJsDebug ? '' : 'min/') .
+			'libs' . ($bAppJsDebug ? '' : '.min') . '.js');
+		$aResult['StaticAppJsLink'] = $this->StaticPath('js/' . ($bAppJsDebug ? '' : 'min/') .
+			($bAdmin ? 'admin' : 'app') . ($bAppJsDebug ? '' : '.min') . '.js');
 
 		if ($this->Config()->Get('labs', 'use_ck_html_editor', false)) {
 			$aResult['StaticEditorJsLink'] = $this->StaticPath('ckeditor/ckeditor.js');
@@ -1489,8 +1355,7 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		$aResult['DevEmail'] = \MailSo\Base\Utils::IdnToUtf8($aResult['DevEmail']);
 
 		// Mobile override
-		if ($bMobile)
-		{
+		if ($bMobile) {
 			$aResult['Layout'] = Enumerations\Layout::NO_PREVIW;
 
 			$aResult['SoundNotification'] = false;
@@ -1506,15 +1371,13 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $aResult;
 	}
 
-	private function getUserLanguagesFromHeader() : array
+	private function getUserLanguagesFromHeader(): array
 	{
 		$aResult = $aList = array();
 		$sAcceptLang = \strtolower($this->Http()->GetServer('HTTP_ACCEPT_LANGUAGE', 'en'));
-		if (!empty($sAcceptLang) && \preg_match_all('/([a-z]{1,8}(?:-[a-z]{1,8})?)(?:;q=([0-9.]+))?/', $sAcceptLang, $aList))
-		{
+		if (!empty($sAcceptLang) && \preg_match_all('/([a-z]{1,8}(?:-[a-z]{1,8})?)(?:;q=([0-9.]+))?/', $sAcceptLang, $aList)) {
 			$aResult = \array_combine($aList[1], $aList[2]);
-			foreach ($aResult as $n => $v)
-			{
+			foreach ($aResult as $n => $v) {
 				$aResult[$n] = $v ? $v : 1;
 			}
 
@@ -1524,16 +1387,14 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $aResult;
 	}
 
-	public function detectUserLanguage(bool $bAdmin = false) : string
+	public function detectUserLanguage(bool $bAdmin = false): string
 	{
 		$sResult = '';
 		$aLangs = $this->getUserLanguagesFromHeader();
 
-		foreach (\array_keys($aLangs) as $sLang)
-		{
+		foreach (\array_keys($aLangs) as $sLang) {
 			$sLang = $this->ValidateLanguage($sLang, '', $bAdmin, true);
-			if (!empty($sLang))
-			{
+			if (!empty($sLang)) {
 				$sResult = $sLang;
 				break;
 			}
@@ -1542,33 +1403,29 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $sResult;
 	}
 
-	private function requestSleep(int $iWait = 1, int $iDelay = 1) : void
+	private function requestSleep(int $iWait = 1, int $iDelay = 1): void
 	{
-		if (0 < $iDelay && 0 < $iWait)
-		{
-			if ($iWait > \time() - $_SERVER['REQUEST_TIME_FLOAT'])
-			{
+		if (0 < $iDelay && 0 < $iWait) {
+			if ($iWait > \time() - $_SERVER['REQUEST_TIME_FLOAT']) {
 				\sleep($iDelay);
 			}
 		}
 	}
 
-	private function loginErrorDelay() : void
+	private function loginErrorDelay(): void
 	{
-		$iDelay = (int) $this->Config()->Get('labs', 'login_fault_delay', 0);
-		if (0 < $iDelay)
-		{
+		$iDelay = (int)$this->Config()->Get('labs', 'login_fault_delay', 0);
+		if (0 < $iDelay) {
 			$this->requestSleep(1, $iDelay);
 		}
 	}
 
-	public function AuthToken(Model\Account $oAccount) : void
+	public function AuthToken(Model\Account $oAccount): void
 	{
 		$this->SetAuthToken($oAccount);
 
 		$aAccounts = $this->GetAccounts($oAccount);
-		if (isset($aAccounts[$oAccount->Email()]))
-		{
+		if (isset($aAccounts[$oAccount->Email()])) {
 			$aAccounts[$oAccount->Email()] = $oAccount->GetAuthToken();
 			$this->SetAccounts($oAccount, $aAccounts);
 		}
@@ -1577,44 +1434,31 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 	/**
 	 * @throws \RainLoop\Exceptions\ClientException
 	 */
-	public function CheckMailConnection(Model\Account $oAccount, bool $bAuthLog = false) : void
+	public function CheckMailConnection(Model\Account $oAccount, bool $bAuthLog = false): void
 	{
-		try
-		{
+		try {
 			$oAccount->IncConnectAndLoginHelper($this->Plugins(), $this->MailClient(), $this->Config());
-		}
-		catch (Exceptions\ClientException $oException)
-		{
+		} catch (Exceptions\ClientException $oException) {
 			throw $oException;
-		}
-		catch (\MailSo\Net\Exceptions\ConnectionException $oException)
-		{
+		} catch (\MailSo\Net\Exceptions\ConnectionException $oException) {
 			throw new Exceptions\ClientException(Notifications::ConnectionError, $oException);
-		}
-		catch (\MailSo\Imap\Exceptions\LoginBadCredentialsException $oException)
-		{
-			if ($bAuthLog)
-			{
+		} catch (\MailSo\Imap\Exceptions\LoginBadCredentialsException $oException) {
+			if ($bAuthLog) {
 				$this->LoggerAuthHelper($oAccount);
 			}
 
-			if ($this->Config()->Get('labs', 'imap_show_login_alert', true))
-			{
+			if ($this->Config()->Get('labs', 'imap_show_login_alert', true)) {
 				throw new Exceptions\ClientException(Notifications::AuthError,
 					$oException, $oException->getAlertFromStatus());
-			}
-			else
-			{
+			} else {
 				throw new Exceptions\ClientException(Notifications::AuthError, $oException);
 			}
-		}
-		catch (\Throwable $oException)
-		{
+		} catch (\Throwable $oException) {
 			throw new Exceptions\ClientException(Notifications::AuthError, $oException);
 		}
 	}
 
-	private function getAdditionalLogParamsByUserLogin(string $sLogin, bool $bAdmin = false) : array
+	private function getAdditionalLogParamsByUserLogin(string $sLogin, bool $bAdmin = false): array
 	{
 		$sHost = $bAdmin ? $this->Http()->GetHost(false, true, true) : \MailSo\Base\Utils::GetDomainFromEmail($sLogin);
 		return array(
@@ -1632,26 +1476,23 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 	 * @throws \RainLoop\Exceptions\ClientException
 	 */
 	public function LoginProcess(string &$sEmail, string &$sPassword, string $sSignMeToken = '',
-		string $sAdditionalCode = '', bool $bAdditionalCodeSignMe = false, bool $bSkipTwoFactorAuth = false) : Model\Account
+								 string $sAdditionalCode = '', bool $bAdditionalCodeSignMe = false, bool $bSkipTwoFactorAuth = false): Model\Account
 	{
 		$sInputEmail = $sEmail;
 
 		$this->Plugins()->RunHook('filter.login-credentials.step-1', array(&$sEmail, &$sPassword));
 
 		$sEmail = \MailSo\Base\Utils::Trim($sEmail);
-		if ($this->Config()->Get('login', 'login_lowercase', true))
-		{
+		if ($this->Config()->Get('login', 'login_lowercase', true)) {
 			$sEmail = \MailSo\Base\Utils::StrToLowerIfAscii($sEmail);
 		}
 
-		if (false === \strpos($sEmail, '@'))
-		{
-			$this->Logger()->Write('The email address "'.$sEmail.'" is not complete', \MailSo\Log\Enumerations\Type::INFO, 'LOGIN');
+		if (false === \strpos($sEmail, '@')) {
+			$this->Logger()->Write('The email address "' . $sEmail . '" is not complete', \MailSo\Log\Enumerations\Type::INFO, 'LOGIN');
 
-			if (false === \strpos($sEmail, '@') && !!$this->Config()->Get('login', 'determine_user_domain', false))
-			{
+			if (false === \strpos($sEmail, '@') && !!$this->Config()->Get('login', 'determine_user_domain', false)) {
 				$sUserHost = \trim($this->Http()->GetHost(false, true, true));
-				$this->Logger()->Write('Determined user domain: '.$sUserHost, \MailSo\Log\Enumerations\Type::INFO, 'LOGIN');
+				$this->Logger()->Write('Determined user domain: ' . $sUserHost, \MailSo\Log\Enumerations\Type::INFO, 'LOGIN');
 
 				$bAdded = false;
 
@@ -1659,67 +1500,56 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 				$aDomainParts = \explode('.', $sUserHost);
 
 				$oDomainProvider = $this->DomainProvider();
-				while (0 < \count($aDomainParts) && 0 < $iLimit)
-				{
+				while (0 < \count($aDomainParts) && 0 < $iLimit) {
 					$sLine = \trim(\implode('.', $aDomainParts), '. ');
 
 					$oDomain = $oDomainProvider->Load($sLine, false);
-					if ($oDomain)
-					{
+					if ($oDomain) {
 						$bAdded = true;
-						$this->Logger()->Write('Check "'.$sLine.'": OK ('.$sEmail.' > '.$sEmail.'@'.$sLine.')',
+						$this->Logger()->Write('Check "' . $sLine . '": OK (' . $sEmail . ' > ' . $sEmail . '@' . $sLine . ')',
 							\MailSo\Log\Enumerations\Type::INFO, 'LOGIN');
 
-						$sEmail = $sEmail.'@'.$sLine;
+						$sEmail = $sEmail . '@' . $sLine;
 						break;
-					}
-					else
-					{
-						$this->Logger()->Write('Check "'.$sLine.'": NO', \MailSo\Log\Enumerations\Type::INFO, 'LOGIN');
+					} else {
+						$this->Logger()->Write('Check "' . $sLine . '": NO', \MailSo\Log\Enumerations\Type::INFO, 'LOGIN');
 					}
 
 					\array_shift($aDomainParts);
 					$iLimit--;
 				}
 
-				if (!$bAdded)
-				{
+				if (!$bAdded) {
 					$sLine = $sUserHost;
 					$oDomain = $oDomainProvider->Load($sLine, true);
-					if ($oDomain && $oDomain)
-					{
+					if ($oDomain && $oDomain) {
 						$bAdded = true;
-						$this->Logger()->Write('Check "'.$sLine.'" with wildcard: OK ('.$sEmail.' > '.$sEmail.'@'.$sLine.')',
+						$this->Logger()->Write('Check "' . $sLine . '" with wildcard: OK (' . $sEmail . ' > ' . $sEmail . '@' . $sLine . ')',
 							\MailSo\Log\Enumerations\Type::INFO, 'LOGIN');
 
-						$sEmail = $sEmail.'@'.$sLine;
-					}
-					else
-					{
-						$this->Logger()->Write('Check "'.$sLine.'" with wildcard: NO', \MailSo\Log\Enumerations\Type::INFO, 'LOGIN');
+						$sEmail = $sEmail . '@' . $sLine;
+					} else {
+						$this->Logger()->Write('Check "' . $sLine . '" with wildcard: NO', \MailSo\Log\Enumerations\Type::INFO, 'LOGIN');
 					}
 				}
 
-				if (!$bAdded)
-				{
+				if (!$bAdded) {
 					$this->Logger()->Write('Domain was not found!', \MailSo\Log\Enumerations\Type::INFO, 'LOGIN');
 				}
 			}
 
 			$sDefDomain = \trim($this->Config()->Get('login', 'default_domain', ''));
-			if (false === \strpos($sEmail, '@') && 0 < \strlen($sDefDomain))
-			{
-				$this->Logger()->Write('Default domain "'.$sDefDomain.'" was used. ('.$sEmail.' > '.$sEmail.'@'.$sDefDomain.')',
+			if (false === \strpos($sEmail, '@') && 0 < \strlen($sDefDomain)) {
+				$this->Logger()->Write('Default domain "' . $sDefDomain . '" was used. (' . $sEmail . ' > ' . $sEmail . '@' . $sDefDomain . ')',
 					\MailSo\Log\Enumerations\Type::INFO, 'LOGIN');
 
-				$sEmail = $sEmail.'@'.$sDefDomain;
+				$sEmail = $sEmail . '@' . $sDefDomain;
 			}
 		}
 
 		$this->Plugins()->RunHook('filter.login-credentials.step-2', array(&$sEmail, &$sPassword));
 
-		if (false === \strpos($sEmail, '@') || 0 === \strlen($sPassword))
-		{
+		if (false === \strpos($sEmail, '@') || 0 === \strlen($sPassword)) {
 			$this->loginErrorDelay();
 
 			throw new Exceptions\ClientException(Notifications::InvalidInputArgument);
@@ -1728,8 +1558,7 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		$this->Logger()->AddSecret($sPassword);
 
 		$sLogin = $sEmail;
-		if ($this->Config()->Get('login', 'login_lowercase', true))
-		{
+		if ($this->Config()->Get('login', 'login_lowercase', true)) {
 			$sLogin = \MailSo\Base\Utils::StrToLowerIfAscii($sLogin);
 		}
 
@@ -1741,60 +1570,47 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 
 		$oAccount = null;
 		$sClientCert = \trim($this->Config()->Get('ssl', 'client_cert', ''));
-		try
-		{
+		try {
 			$oAccount = $this->LoginProvide($sEmail, $sLogin, $sPassword, $sSignMeToken, $sClientCert, true);
 
-			if (!$oAccount)
-			{
+			if (!$oAccount) {
 				throw new Exceptions\ClientException(Notifications::AuthError);
 			}
 
 			$this->Plugins()->RunHook('event.login-post-login-provide', array($oAccount));
-		}
-		catch (\Throwable $oException)
-		{
+		} catch (\Throwable $oException) {
 			$this->loginErrorDelay();
 			$this->LoggerAuthHelper($oAccount, $this->getAdditionalLogParamsByUserLogin($sInputEmail));
 			throw $oException;
 		}
 
 		// 2FA
-		if (!$bSkipTwoFactorAuth && $this->TwoFactorAuthProvider()->IsActive())
-		{
+		if (!$bSkipTwoFactorAuth && $this->TwoFactorAuthProvider()->IsActive()) {
 			$aData = $this->getTwoFactorInfo($oAccount);
-			if ($aData && isset($aData['IsSet'], $aData['Enable']) && !empty($aData['Secret']) && $aData['IsSet'] && $aData['Enable'])
-			{
-				$sSecretHash = \md5(APP_SALT.$aData['Secret'].Utils::Fingerprint());
+			if ($aData && isset($aData['IsSet'], $aData['Enable']) && !empty($aData['Secret']) && $aData['IsSet'] && $aData['Enable']) {
+				$sSecretHash = \md5(APP_SALT . $aData['Secret'] . Utils::Fingerprint());
 				$sSecretCookieHash = Utils::GetCookie(self::AUTH_TFA_SIGN_ME_TOKEN_KEY, '');
 
-				if (empty($sSecretCookieHash) || $sSecretHash !== $sSecretCookieHash)
-				{
+				if (empty($sSecretCookieHash) || $sSecretHash !== $sSecretCookieHash) {
 					$sAdditionalCode = \trim($sAdditionalCode);
-					if (empty($sAdditionalCode))
-					{
-						$this->Logger()->Write('TFA: Required Code for '.$oAccount->ParentEmailHelper().' account.');
+					if (empty($sAdditionalCode)) {
+						$this->Logger()->Write('TFA: Required Code for ' . $oAccount->ParentEmailHelper() . ' account.');
 
 						throw new Exceptions\ClientException(Notifications::AccountTwoFactorAuthRequired);
-					}
-					else
-					{
-						$this->Logger()->Write('TFA: Verify Code for '.$oAccount->ParentEmailHelper().' account.');
+					} else {
+						$this->Logger()->Write('TFA: Verify Code for ' . $oAccount->ParentEmailHelper() . ' account.');
 
 						$bUseBackupCode = false;
-						if (6 < \strlen($sAdditionalCode) && !empty($aData['BackupCodes']))
-						{
+						if (6 < \strlen($sAdditionalCode) && !empty($aData['BackupCodes'])) {
 							$aBackupCodes = \explode(' ', \trim(\preg_replace('/[^\d]+/', ' ', $aData['BackupCodes'])));
 							$bUseBackupCode = \in_array($sAdditionalCode, $aBackupCodes);
 
-							if ($bUseBackupCode)
-							{
+							if ($bUseBackupCode) {
 								$this->removeBackupCodeFromTwoFactorInfo($oAccount->ParentEmailHelper(), $sAdditionalCode);
 							}
 						}
 
-						if (!$bUseBackupCode && !$this->TwoFactorAuthProvider()->VerifyCode($aData['Secret'], $sAdditionalCode))
-						{
+						if (!$bUseBackupCode && !$this->TwoFactorAuthProvider()->VerifyCode($aData['Secret'], $sAdditionalCode)) {
 							$this->loginErrorDelay();
 
 							$this->LoggerAuthHelper($oAccount);
@@ -1802,8 +1618,7 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 							throw new Exceptions\ClientException(Notifications::AccountTwoFactorAuthError);
 						}
 
-						if ($bAdditionalCodeSignMe)
-						{
+						if ($bAdditionalCodeSignMe) {
 							Utils::SetCookie(self::AUTH_TFA_SIGN_ME_TOKEN_KEY, $sSecretHash,
 								\time() + 60 * 60 * 24 * 14);
 						}
@@ -1812,12 +1627,9 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 			}
 		}
 
-		try
-		{
+		try {
 			$this->CheckMailConnection($oAccount, true);
-		}
-		catch (\Throwable $oException)
-		{
+		} catch (\Throwable $oException) {
 			$this->loginErrorDelay();
 
 			throw $oException;
@@ -1826,30 +1638,24 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $oAccount;
 	}
 
-	public function GetAccounts(Model\Account $oAccount) : array
+	public function GetAccounts(Model\Account $oAccount): array
 	{
-		if ($this->GetCapa(false, false, Enumerations\Capa::ADDITIONAL_ACCOUNTS, $oAccount))
-		{
+		if ($this->GetCapa(false, false, Enumerations\Capa::ADDITIONAL_ACCOUNTS, $oAccount)) {
 			$sAccounts = $this->StorageProvider()->Get($oAccount,
 				Providers\Storage\Enumerations\StorageType::CONFIG,
 				'accounts'
 			);
 
 			$aAccounts = array();
-			if ('' !== $sAccounts && '{' === \substr($sAccounts, 0, 1))
-			{
+			if ('' !== $sAccounts && '{' === \substr($sAccounts, 0, 1)) {
 				$aAccounts = \json_decode($sAccounts, true);
 			}
 
-			if (\is_array($aAccounts) && 0 < \count($aAccounts))
-			{
-				if (1 === \count($aAccounts))
-				{
+			if (\is_array($aAccounts) && 0 < \count($aAccounts)) {
+				if (1 === \count($aAccounts)) {
 					$this->SetAccounts($oAccount, array());
 
-				}
-				else if (1 < \count($aAccounts))
-				{
+				} else if (1 < \count($aAccounts)) {
 					$sOrder = $this->StorageProvider()->Get($oAccount,
 						Providers\Storage\Enumerations\StorageType::CONFIG,
 						'accounts_identities_order'
@@ -1857,8 +1663,7 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 
 					$aOrder = empty($sOrder) ? array() : \json_decode($sOrder, true);
 					if (isset($aOrder['Accounts']) && \is_array($aOrder['Accounts']) &&
-						1 < \count($aOrder['Accounts']))
-					{
+						1 < \count($aOrder['Accounts'])) {
 						$aAccounts = \array_merge(\array_flip($aOrder['Accounts']), $aAccounts);
 
 						$aAccounts = \array_filter($aAccounts, function ($sHash) {
@@ -1872,22 +1677,19 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		}
 
 		$aAccounts = array();
-		if (!$oAccount->IsAdditionalAccount())
-		{
+		if (!$oAccount->IsAdditionalAccount()) {
 			$aAccounts[$oAccount->Email()] = $oAccount->GetAuthToken();
 		}
 
 		return $aAccounts;
 	}
 
-	public function GetIdentityByID(Model\Account $oAccount, string $sID, bool $bFirstOnEmpty = false) : ?Model\Identity
+	public function GetIdentityByID(Model\Account $oAccount, string $sID, bool $bFirstOnEmpty = false): ?Model\Identity
 	{
 		$aIdentities = $this->GetIdentities($oAccount);
 
-		foreach ($aIdentities as $oIdentity)
-		{
-			if ($oIdentity && $sID === $oIdentity->Id())
-			{
+		foreach ($aIdentities as $oIdentity) {
+			if ($oIdentity && $sID === $oIdentity->Id()) {
 				return $oIdentity;
 			}
 		}
@@ -1895,19 +1697,16 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $bFirstOnEmpty && isset($aIdentities[0]) ? $aIdentities[0] : null;
 	}
 
-	public function SetAccounts(Model\Account $oAccount, array $aAccounts = array()) : void
+	public function SetAccounts(Model\Account $oAccount, array $aAccounts = array()): void
 	{
 		$sParentEmail = $oAccount->ParentEmailHelper();
 		if (!$aAccounts ||
-			(1 === \count($aAccounts) && !empty($aAccounts[$sParentEmail])))
-		{
+			(1 === \count($aAccounts) && !empty($aAccounts[$sParentEmail]))) {
 			$this->StorageProvider()->Clear($oAccount,
 				Providers\Storage\Enumerations\StorageType::CONFIG,
 				'accounts'
 			);
-		}
-		else
-		{
+		} else {
 			$this->StorageProvider()->Put($oAccount,
 				Providers\Storage\Enumerations\StorageType::CONFIG,
 				'accounts',
@@ -1919,15 +1718,13 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 	/**
 	 * @throws \MailSo\Base\Exceptions\Exception
 	 */
-	public function getAccountUnreadCountFromHash(string $sHash) : int
+	public function getAccountUnreadCountFromHash(string $sHash): int
 	{
 		$iResult = 0;
 
 		$oAccount = $this->GetAccountFromCustomToken($sHash, false);
-		if ($oAccount)
-		{
-			try
-			{
+		if ($oAccount) {
+			try {
 				$oMailClient = new \MailSo\Mail\MailClient();
 				$oMailClient->SetLogger($this->Logger());
 
@@ -1936,9 +1733,7 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 				$iResult = $oMailClient->InboxUnreadCount();
 
 				$oMailClient->LogoutAndDisconnect();
-			}
-			catch (\Throwable $oException)
-			{
+			} catch (\Throwable $oException) {
 				$this->Logger()->WriteException($oException);
 			}
 		}
@@ -1946,81 +1741,75 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $iResult;
 	}
 
-	public function setConfigFromParams(Config\Application $oConfig, string $sParamName, string $sConfigSector, string $sConfigName, string $sType = 'string', ?callable $mStringCallback = null) : void
+	public function setConfigFromParams(Config\Application $oConfig, string $sParamName, string $sConfigSector, string $sConfigName, string $sType = 'string', ?callable $mStringCallback = null): void
 	{
 		$sValue = $this->GetActionParam($sParamName, '');
-		if ($this->HasActionParam($sParamName))
-		{
-			switch ($sType)
-			{
+		if ($this->HasActionParam($sParamName)) {
+			switch ($sType) {
 				default:
 				case 'string':
-					$sValue = (string) $sValue;
-					if ($mStringCallback && is_callable($mStringCallback))
-					{
+					$sValue = (string)$sValue;
+					if ($mStringCallback && is_callable($mStringCallback)) {
 						$sValue = call_user_func($mStringCallback, $sValue);
 					}
 
-					$oConfig->Set($sConfigSector, $sConfigName, (string) $sValue);
+					$oConfig->Set($sConfigSector, $sConfigName, (string)$sValue);
 					break;
 
 				case 'dummy':
-					$sValue = (string) $this->GetActionParam('ContactsPdoPassword', APP_DUMMY);
-					if (APP_DUMMY !== $sValue)
-					{
-						$oConfig->Set($sConfigSector, $sConfigName, (string) $sValue);
+					$sValue = (string)$this->GetActionParam('ContactsPdoPassword', APP_DUMMY);
+					if (APP_DUMMY !== $sValue) {
+						$oConfig->Set($sConfigSector, $sConfigName, (string)$sValue);
 					}
 					break;
 
 				case 'int':
-					$iValue = (int) $sValue;
+					$iValue = (int)$sValue;
 					$oConfig->Set($sConfigSector, $sConfigName, $iValue);
 					break;
 
 				case 'bool':
-					$oConfig->Set($sConfigSector, $sConfigName, '1' === (string) $sValue);
+					$oConfig->Set($sConfigSector, $sConfigName, '1' === (string)$sValue);
 					break;
 			}
 		}
 	}
 
-	public function DoNoop() : array
+	public function DoNoop(): array
 	{
 		$this->initMailClientConnection();
 		return $this->TrueResponse(__FUNCTION__);
 	}
 
-	public function DoPing() : array
+	public function DoPing(): array
 	{
 		return $this->DefaultResponse(__FUNCTION__, 'Pong');
 	}
 
-	public function DoVersion() : array
+	public function DoVersion(): array
 	{
 		return $this->DefaultResponse(__FUNCTION__,
-			APP_VERSION === (string) $this->GetActionParam('Version', ''));
+			APP_VERSION === (string)$this->GetActionParam('Version', ''));
 	}
 
-	public function MainClearFileName(string $sFileName, string $sContentType, string $sMimeIndex, int $iMaxLength = 250) : string
+	public function MainClearFileName(string $sFileName, string $sContentType, string $sMimeIndex, int $iMaxLength = 250): string
 	{
-		$sFileName = 0 === \strlen($sFileName) ? \preg_replace('/[^a-zA-Z0-9]/', '.', (empty($sMimeIndex) ? '' : $sMimeIndex.'.').$sContentType) : $sFileName;
+		$sFileName = 0 === \strlen($sFileName) ? \preg_replace('/[^a-zA-Z0-9]/', '.', (empty($sMimeIndex) ? '' : $sMimeIndex . '.') . $sContentType) : $sFileName;
 		$sClearedFileName = \MailSo\Base\Utils::StripSpaces(\preg_replace('/[\.]+/', '.', $sFileName));
 		$sExt = \MailSo\Base\Utils::GetFileExtension($sClearedFileName);
 
-		if (10 < $iMaxLength && $iMaxLength < \strlen($sClearedFileName) - \strlen($sExt))
-		{
-			$sClearedFileName = \substr($sClearedFileName, 0, $iMaxLength).(empty($sExt) ? '' : '.'.$sExt);
+		if (10 < $iMaxLength && $iMaxLength < \strlen($sClearedFileName) - \strlen($sExt)) {
+			$sClearedFileName = \substr($sClearedFileName, 0, $iMaxLength) . (empty($sExt) ? '' : '.' . $sExt);
 		}
 
 		return \MailSo\Base\Utils::ClearFileName(\MailSo\Base\Utils::Utf8Clear($sClearedFileName));
 	}
 
-	private function getUploadErrorMessageByCode(int $iError, int &$iClientError) : string
+	private function getUploadErrorMessageByCode(int $iError, int &$iClientError): string
 	{
 		$sError = '';
 		$iClientError = UploadClientError::NORMAL;
-		switch($iError)
-		{
+		switch ($iError) {
 			case UPLOAD_ERR_OK:
 				break;
 			case UPLOAD_ERR_INI_SIZE:
@@ -2062,7 +1851,7 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $sError;
 	}
 
-	public function Upload() : array
+	public function Upload(): array
 	{
 		$oAccount = $this->getAccountFromToken();
 
@@ -2071,15 +1860,11 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		$aFile = $this->GetActionParam('File', null);
 		$iError = $this->GetActionParam('Error', Enumerations\UploadError::UNKNOWN);
 
-		if ($oAccount && UPLOAD_ERR_OK === $iError && \is_array($aFile))
-		{
-			$sSavedName = 'upload-post-'.\md5($aFile['name'].$aFile['tmp_name']);
-			if (!$this->FilesProvider()->MoveUploadedFile($oAccount, $sSavedName, $aFile['tmp_name']))
-			{
+		if ($oAccount && UPLOAD_ERR_OK === $iError && \is_array($aFile)) {
+			$sSavedName = 'upload-post-' . \md5($aFile['name'] . $aFile['tmp_name']);
+			if (!$this->FilesProvider()->MoveUploadedFile($oAccount, $sSavedName, $aFile['tmp_name'])) {
 				$iError = Enumerations\UploadError::ON_SAVING;
-			}
-			else
-			{
+			} else {
 				$sUploadName = $aFile['name'];
 				$iSize = $aFile['size'];
 				$sMimeType = $aFile['type'];
@@ -2088,18 +1873,16 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 					'Name' => $sUploadName,
 					'TempName' => $sSavedName,
 					'MimeType' => $sMimeType,
-					'Size' =>  (int) $iSize
+					'Size' => (int)$iSize
 				);
 			}
 		}
 
-		if (UPLOAD_ERR_OK !== $iError)
-		{
+		if (UPLOAD_ERR_OK !== $iError) {
 			$iClientError = Enumerations\UploadClientError::NORMAL;
 			$sError = $this->getUploadErrorMessageByCode($iError, $iClientError);
 
-			if (!empty($sError))
-			{
+			if (!empty($sError)) {
 				$aResponse['ErrorCode'] = $iClientError;
 				$aResponse['Error'] = $sError;
 			}
@@ -2108,12 +1891,11 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $this->DefaultResponse(__FUNCTION__, $aResponse);
 	}
 
-	public function UploadBackground() : array
+	public function UploadBackground(): array
 	{
 		$oAccount = $this->getAccountFromToken();
 
-		if (!$this->GetCapa(false, false, Enumerations\Capa::USER_BACKGROUND, $oAccount))
-		{
+		if (!$this->GetCapa(false, false, Enumerations\Capa::USER_BACKGROUND, $oAccount)) {
 			return $this->FalseResponse(__FUNCTION__);
 		}
 
@@ -2123,27 +1905,19 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		$aFile = $this->GetActionParam('File', null);
 		$iError = $this->GetActionParam('Error', Enumerations\UploadError::UNKNOWN);
 
-		if ($oAccount && UPLOAD_ERR_OK === $iError && \is_array($aFile))
-		{
+		if ($oAccount && UPLOAD_ERR_OK === $iError && \is_array($aFile)) {
 			$sMimeType = \strtolower(\MailSo\Base\Utils::MimeContentType($aFile['name']));
-			if (\in_array($sMimeType, array('image/png', 'image/jpg', 'image/jpeg')))
-			{
-				$sSavedName = 'upload-post-'.\md5($aFile['name'].$aFile['tmp_name']);
-				if (!$this->FilesProvider()->MoveUploadedFile($oAccount, $sSavedName, $aFile['tmp_name']))
-				{
+			if (\in_array($sMimeType, array('image/png', 'image/jpg', 'image/jpeg'))) {
+				$sSavedName = 'upload-post-' . \md5($aFile['name'] . $aFile['tmp_name']);
+				if (!$this->FilesProvider()->MoveUploadedFile($oAccount, $sSavedName, $aFile['tmp_name'])) {
 					$iError = Enumerations\UploadError::ON_SAVING;
-				}
-				else
-				{
+				} else {
 					$rData = $this->FilesProvider()->GetFile($oAccount, $sSavedName);
-					if (\is_resource($rData))
-					{
+					if (\is_resource($rData)) {
 						$sData = \stream_get_contents($rData);
-						if (!empty($sData) && 0 < \strlen($sData))
-						{
+						if (!empty($sData) && 0 < \strlen($sData)) {
 							$sName = $aFile['name'];
-							if (empty($sName))
-							{
+							if (empty($sName)) {
 								$sName = '_';
 							}
 
@@ -2155,12 +1929,10 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 									'ContentType' => $sMimeType,
 									'Raw' => \base64_encode($sData)
 								))
-							))
-							{
+							)) {
 								$oSettings = $this->SettingsProvider()->Load($oAccount);
-								if ($oSettings)
-								{
-									$sHash = \MailSo\Base\Utils::Md5Rand($sName.APP_VERSION.APP_SALT);
+								if ($oSettings) {
+									$sHash = \MailSo\Base\Utils::Md5Rand($sName . APP_VERSION . APP_SALT);
 
 									$oSettings->SetConf('UserBackgroundName', $sName);
 									$oSettings->SetConf('UserBackgroundHash', $sHash);
@@ -2172,8 +1944,7 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 						unset($sData);
 					}
 
-					if (\is_resource($rData))
-					{
+					if (\is_resource($rData)) {
 						\fclose($rData);
 					}
 
@@ -2181,20 +1952,16 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 				}
 
 				$this->FilesProvider()->Clear($oAccount, $sSavedName);
-			}
-			else
-			{
+			} else {
 				$iError = Enumerations\UploadError::FILE_TYPE;
 			}
 		}
 
-		if (UPLOAD_ERR_OK !== $iError)
-		{
+		if (UPLOAD_ERR_OK !== $iError) {
 			$iClientError = Enumerations\UploadClientError::NORMAL;
 			$sError = $this->getUploadErrorMessageByCode($iError, $iClientError);
 
-			if (!empty($sError))
-			{
+			if (!empty($sError)) {
 				return $this->FalseResponse(__FUNCTION__, $iClientError, $sError);
 			}
 		}
@@ -2205,41 +1972,32 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		) : false);
 	}
 
-	private function importContactsFromCsvFile(Model\Account $oAccount, /*resource*/ $rFile, string $sFileStart) : int
+	private function importContactsFromCsvFile(Model\Account $oAccount, /*resource*/ $rFile, string $sFileStart): int
 	{
 		$iCount = 0;
 		$aHeaders = null;
 		$aData = array();
 
-		if ($oAccount && \is_resource($rFile))
-		{
+		if ($oAccount && \is_resource($rFile)) {
 			$oAddressBookProvider = $this->AddressBookProvider($oAccount);
-			if ($oAddressBookProvider && $oAddressBookProvider->IsActive())
-			{
-				$sDelimiter = ((int) \strpos($sFileStart, ',') > (int) \strpos($sFileStart, ';')) ? ',' : ';';
+			if ($oAddressBookProvider && $oAddressBookProvider->IsActive()) {
+				$sDelimiter = ((int)\strpos($sFileStart, ',') > (int)\strpos($sFileStart, ';')) ? ',' : ';';
 
 				\setlocale(LC_CTYPE, 'en_US.UTF-8');
-				while (false !== ($mRow = \fgetcsv($rFile, 5000, $sDelimiter, '"')))
-				{
-					if (null === $aHeaders)
-					{
-						if (3 >= \count($mRow))
-						{
+				while (false !== ($mRow = \fgetcsv($rFile, 5000, $sDelimiter, '"'))) {
+					if (null === $aHeaders) {
+						if (3 >= \count($mRow)) {
 							return 0;
 						}
 
 						$aHeaders = $mRow;
 
-						foreach ($aHeaders as $iIndex => $sHeaderValue)
-						{
+						foreach ($aHeaders as $iIndex => $sHeaderValue) {
 							$aHeaders[$iIndex] = \MailSo\Base\Utils::Utf8Clear($sHeaderValue);
 						}
-					}
-					else
-					{
+					} else {
 						$aNewItem = array();
-						foreach ($aHeaders as $iIndex => $sHeaderValue)
-						{
+						foreach ($aHeaders as $iIndex => $sHeaderValue) {
 							$aNewItem[$sHeaderValue] = isset($mRow[$iIndex]) ? $mRow[$iIndex] : '';
 						}
 
@@ -2247,8 +2005,7 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 					}
 				}
 
-				if (0 < \count($aData))
-				{
+				if (0 < \count($aData)) {
 					$this->Logger()->Write('Import contacts from csv');
 					$iCount = $oAddressBookProvider->ImportCsvArray($oAccount->ParentEmailHelper(), $aData);
 				}
@@ -2258,22 +2015,18 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $iCount;
 	}
 
-	private function importContactsFromVcfFile(Model\Account $oAccount, /*resource*/ $rFile) : int
+	private function importContactsFromVcfFile(Model\Account $oAccount, /*resource*/ $rFile): int
 	{
 		$iCount = 0;
-		if ($oAccount && \is_resource($rFile))
-		{
+		if ($oAccount && \is_resource($rFile)) {
 			$oAddressBookProvider = $this->AddressBookProvider($oAccount);
-			if ($oAddressBookProvider && $oAddressBookProvider->IsActive())
-			{
+			if ($oAddressBookProvider && $oAddressBookProvider->IsActive()) {
 				$sFile = \stream_get_contents($rFile);
-				if (\is_resource($rFile))
-				{
+				if (\is_resource($rFile)) {
 					\fclose($rFile);
 				}
 
-				if (is_string($sFile) && 5 < \strlen($sFile))
-				{
+				if (is_string($sFile) && 5 < \strlen($sFile)) {
 					$this->Logger()->Write('Import contacts from vcf');
 					$iCount = $oAddressBookProvider->ImportVcfFile($oAccount->ParentEmailHelper(), $sFile);
 				}
@@ -2286,7 +2039,7 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 	/**
 	 * @throws \MailSo\Base\Exceptions\Exception
 	 */
-	public function Append() : bool
+	public function Append(): bool
 	{
 		$oAccount = $this->initMailClientConnection();
 
@@ -2296,17 +2049,13 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		if ($oAccount instanceof Model\Account &&
 			$this->Config()->Get('labs', 'allow_message_append', false) &&
 			isset($_FILES, $_FILES['AppendFile'], $_FILES['AppendFile']['name'],
-				$_FILES['AppendFile']['tmp_name'], $_FILES['AppendFile']['size']))
-		{
-			if (is_string($_FILES['AppendFile']['tmp_name']) && 0 < strlen($_FILES['AppendFile']['tmp_name']))
-			{
-				if (\UPLOAD_ERR_OK === (int) $_FILES['AppendFile']['error'] && !empty($sFolderFullNameRaw))
-				{
-					$sSavedName = 'append-post-'.md5($sFolderFullNameRaw.$_FILES['AppendFile']['name'].$_FILES['AppendFile']['tmp_name']);
+				$_FILES['AppendFile']['tmp_name'], $_FILES['AppendFile']['size'])) {
+			if (is_string($_FILES['AppendFile']['tmp_name']) && 0 < strlen($_FILES['AppendFile']['tmp_name'])) {
+				if (\UPLOAD_ERR_OK === (int)$_FILES['AppendFile']['error'] && !empty($sFolderFullNameRaw)) {
+					$sSavedName = 'append-post-' . md5($sFolderFullNameRaw . $_FILES['AppendFile']['name'] . $_FILES['AppendFile']['tmp_name']);
 
 					if ($this->FilesProvider()->MoveUploadedFile($oAccount,
-						$sSavedName, $_FILES['AppendFile']['tmp_name']))
-					{
+						$sSavedName, $_FILES['AppendFile']['tmp_name'])) {
 						$iMessageStreamSize = $this->FilesProvider()->FileSize($oAccount, $sSavedName);
 						$rMessageStream = $this->FilesProvider()->GetFile($oAccount, $sSavedName);
 
@@ -2321,135 +2070,110 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $this->DefaultResponse(__FUNCTION__, true);
 	}
 
-	public function Capa(bool $bAdmin, bool $bMobile = false, ?Model\Account $oAccount = null) : array
+	public function Capa(bool $bAdmin, bool $bMobile = false, ?Model\Account $oAccount = null): array
 	{
 		$oConfig = $this->Config();
 
 		$aResult = array();
 
-		if ($oConfig->Get('capa', 'folders', true))
-		{
+		if ($oConfig->Get('capa', 'folders', true)) {
 			$aResult[] = Enumerations\Capa::FOLDERS;
 
-			if ($oConfig->Get('capa', 'messagelist_actions', true))
-			{
+			if ($oConfig->Get('capa', 'messagelist_actions', true)) {
 				$aResult[] = Enumerations\Capa::MESSAGELIST_ACTIONS;
 
-				if ($oConfig->Get('capa', 'dangerous_actions', true))
-				{
+				if ($oConfig->Get('capa', 'dangerous_actions', true)) {
 					$aResult[] = Enumerations\Capa::DANGEROUS_ACTIONS;
 				}
 			}
 		}
 
-		if ($oConfig->Get('capa', 'reload', true))
-		{
+		if ($oConfig->Get('capa', 'reload', true)) {
 			$aResult[] = Enumerations\Capa::RELOAD;
 		}
 
-		if ($oConfig->Get('capa', 'quota', true))
-		{
+		if ($oConfig->Get('capa', 'quota', true)) {
 			$aResult[] = Enumerations\Capa::QUOTA;
 		}
 
-		if ($oConfig->Get('capa', 'settings', true))
-		{
+		if ($oConfig->Get('capa', 'settings', true)) {
 			$aResult[] = Enumerations\Capa::SETTINGS;
 
-			if ($oConfig->Get('webmail', 'allow_additional_accounts', false))
-			{
+			if ($oConfig->Get('webmail', 'allow_additional_accounts', false)) {
 				$aResult[] = Enumerations\Capa::ADDITIONAL_ACCOUNTS;
 			}
 
-			if ($oConfig->Get('webmail', 'allow_additional_identities', false))
-			{
+			if ($oConfig->Get('webmail', 'allow_additional_identities', false)) {
 				$aResult[] = Enumerations\Capa::IDENTITIES;
 			}
 
-			if ($oConfig->Get('capa', 'x-templates', true) && !$bMobile)
-			{
+			if ($oConfig->Get('capa', 'x-templates', true) && !$bMobile) {
 				$aResult[] = Enumerations\Capa::TEMPLATES;
 			}
 
-			if ($oConfig->Get('webmail', 'allow_themes', false) && !$bMobile)
-			{
+			if ($oConfig->Get('webmail', 'allow_themes', false) && !$bMobile) {
 				$aResult[] = Enumerations\Capa::THEMES;
 			}
 
-			if ($oConfig->Get('webmail', 'allow_user_background', false) && !$bMobile)
-			{
+			if ($oConfig->Get('webmail', 'allow_user_background', false) && !$bMobile) {
 				$aResult[] = Enumerations\Capa::USER_BACKGROUND;
 			}
 
-			if ($oConfig->Get('security', 'openpgp', false) && !$bMobile)
-			{
+			if ($oConfig->Get('security', 'openpgp', false) && !$bMobile) {
 				$aResult[] = Enumerations\Capa::OPEN_PGP;
 			}
 
-			if ($oConfig->Get('capa', 'filters', false))
-			{
+			if ($oConfig->Get('capa', 'filters', false)) {
 				$aResult[] = Enumerations\Capa::FILTERS;
-				if ($bAdmin || ($oAccount && $oAccount->Domain()->UseSieve()))
-				{
+				if ($bAdmin || ($oAccount && $oAccount->Domain()->UseSieve())) {
 					$aResult[] = Enumerations\Capa::SIEVE;
 				}
 			}
 		}
 
 		if ($oConfig->Get('security', 'allow_two_factor_auth', false) &&
-			($bAdmin || ($oAccount && !$oAccount->IsAdditionalAccount())))
-		{
+			($bAdmin || ($oAccount && !$oAccount->IsAdditionalAccount()))) {
 			$aResult[] = Enumerations\Capa::TWO_FACTOR;
 
 			if ($oConfig->Get('security', 'force_two_factor_auth', false) &&
-				($bAdmin || ($oAccount && !$oAccount->IsAdditionalAccount())))
-			{
+				($bAdmin || ($oAccount && !$oAccount->IsAdditionalAccount()))) {
 				$aResult[] = Enumerations\Capa::TWO_FACTOR_FORCE;
 			}
 		}
 
-		if ($oConfig->Get('capa', 'help', true) && !$bMobile)
-		{
+		if ($oConfig->Get('capa', 'help', true) && !$bMobile) {
 			$aResult[] = Enumerations\Capa::HELP;
 		}
 
-		if ($oConfig->Get('capa', 'attachments_actions', false))
-		{
+		if ($oConfig->Get('capa', 'attachments_actions', false)) {
 			$aResult[] = Enumerations\Capa::ATTACHMENTS_ACTIONS;
 		}
 
-		if ($oConfig->Get('capa', 'message_actions', true))
-		{
+		if ($oConfig->Get('capa', 'message_actions', true)) {
 			$aResult[] = Enumerations\Capa::MESSAGE_ACTIONS;
 		}
 
-		if ($oConfig->Get('capa', 'composer', true))
-		{
+		if ($oConfig->Get('capa', 'composer', true)) {
 			$aResult[] = Enumerations\Capa::COMPOSER;
 
-			if ($oConfig->Get('capa', 'contacts', true))
-			{
+			if ($oConfig->Get('capa', 'contacts', true)) {
 				$aResult[] = Enumerations\Capa::CONTACTS;
 			}
 		}
 
-		if ($oConfig->Get('capa', 'search', true))
-		{
+		if ($oConfig->Get('capa', 'search', true)) {
 			$aResult[] = Enumerations\Capa::SEARCH;
 
-			if ($oConfig->Get('capa', 'search_adv', true) && !$bMobile)
-			{
+			if ($oConfig->Get('capa', 'search_adv', true) && !$bMobile) {
 				$aResult[] = Enumerations\Capa::SEARCH_ADV;
 			}
 		}
 
-		if ($oConfig->Get('interface', 'show_attachment_thumbnail', true))
-		{
+		if ($oConfig->Get('interface', 'show_attachment_thumbnail', true)) {
 			$aResult[] = Enumerations\Capa::ATTACHMENT_THUMBNAILS;
 		}
 
-		if ($oConfig->Get('labs', 'allow_prefetch', false) && !$bMobile)
-		{
+		if ($oConfig->Get('labs', 'allow_prefetch', false) && !$bMobile) {
 			$aResult[] = Enumerations\Capa::PREFETCH;
 		}
 
@@ -2458,44 +2182,39 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $aResult;
 	}
 
-	public function GetCapa(bool $bAdmin, bool $bMobile, string $sName, ?Model\Account $oAccount = null) : bool
+	public function GetCapa(bool $bAdmin, bool $bMobile, string $sName, ?Model\Account $oAccount = null): bool
 	{
 		return \in_array($sName, $this->Capa($bAdmin, $bMobile, $oAccount));
 	}
 
-	public function etag(string $sKey) : string
+	public function etag(string $sKey): string
 	{
-		return \md5('Etag:'.\md5($sKey.\md5($this->Config()->Get('cache', 'index', ''))));
+		return \md5('Etag:' . \md5($sKey . \md5($this->Config()->Get('cache', 'index', ''))));
 	}
 
-	public function cacheByKey(string $sKey, bool $bForce = false) : bool
+	public function cacheByKey(string $sKey, bool $bForce = false): bool
 	{
 		$bResult = false;
-		if (!empty($sKey) && ($bForce || ($this->Config()->Get('cache', 'enable', true) && $this->Config()->Get('cache', 'http', true))))
-		{
+		if (!empty($sKey) && ($bForce || ($this->Config()->Get('cache', 'enable', true) && $this->Config()->Get('cache', 'http', true)))) {
 			$iExpires = $this->Config()->Get('cache', 'http_expires', 3600);
-			if (0 < $iExpires)
-			{
+			if (0 < $iExpires) {
 				$this->oHttp->ServerUseCache($this->etag($sKey), 1382478804, \time() + $iExpires);
 				$bResult = true;
 			}
 		}
 
-		if (!$bResult)
-		{
+		if (!$bResult) {
 			$this->oHttp->ServerNoCache();
 		}
 
 		return $bResult;
 	}
 
-	public function verifyCacheByKey(string $sKey, bool $bForce = false) : void
+	public function verifyCacheByKey(string $sKey, bool $bForce = false): void
 	{
-		if (!empty($sKey) && ($bForce || $this->Config()->Get('cache', 'enable', true) && $this->Config()->Get('cache', 'http', true)))
-		{
+		if (!empty($sKey) && ($bForce || $this->Config()->Get('cache', 'enable', true) && $this->Config()->Get('cache', 'http', true))) {
 			$sIfNoneMatch = $this->Http()->GetHeader('If-None-Match', '');
-			if ($this->etag($sKey) === $sIfNoneMatch)
-			{
+			if ($this->etag($sKey) === $sIfNoneMatch) {
 				$this->Http()->StatusHeader(304);
 				$this->cacheByKey($sKey);
 				exit(0);
@@ -2503,24 +2222,18 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		}
 	}
 
-	private function initMailClientConnection() : ?Model\Account
+	private function initMailClientConnection(): ?Model\Account
 	{
 		$oAccount = null;
 
-		if (!$this->MailClient()->IsLoggined())
-		{
+		if (!$this->MailClient()->IsLoggined()) {
 			$oAccount = $this->getAccountFromToken();
 
-			try
-			{
+			try {
 				$oAccount->IncConnectAndLoginHelper($this->Plugins(), $this->MailClient(), $this->Config());
-			}
-			catch (\MailSo\Net\Exceptions\ConnectionException $oException)
-			{
+			} catch (\MailSo\Net\Exceptions\ConnectionException $oException) {
 				throw new Exceptions\ClientException(Notifications::ConnectionError, $oException);
-			}
-			catch (\Throwable $oException)
-			{
+			} catch (\Throwable $oException) {
 				throw new Exceptions\ClientException(Notifications::AuthError, $oException);
 			}
 
@@ -2530,30 +2243,28 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $oAccount;
 	}
 
-	private function getDecodedRawKeyValue(string $sRawKey) : array
+	private function getDecodedRawKeyValue(string $sRawKey): array
 	{
 		return empty($sRawKey) ? array() : Utils::DecodeKeyValuesQ($sRawKey);
 	}
 
-	public function StaticCache() : string
+	public function StaticCache(): string
 	{
 		static $sCache = null;
-		if (!$sCache)
-		{
-			$sCache = \md5(APP_VERSION.$this->Plugins()->Hash());
+		if (!$sCache) {
+			$sCache = \md5(APP_VERSION . $this->Plugins()->Hash());
 		}
 		return $sCache;
 	}
 
-	public function ThemeLink(string $sTheme, bool $bAdmin) : string
+	public function ThemeLink(string $sTheme, bool $bAdmin): string
 	{
-		return './?/Css/0/'.($bAdmin ? 'Admin' : 'User').'/-/'.$sTheme.'/-/'.$this->StaticCache().'/Hash/-/';
+		return './?/Css/0/' . ($bAdmin ? 'Admin' : 'User') . '/-/' . $sTheme . '/-/' . $this->StaticCache() . '/Hash/-/';
 	}
 
-	public function ValidateTheme(string $sTheme, bool $bMobile = false) : string
+	public function ValidateTheme(string $sTheme, bool $bMobile = false): string
 	{
-		if ($bMobile)
-		{
+		if ($bMobile) {
 			return 'Mobile';
 		}
 
@@ -2561,7 +2272,7 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 			$sTheme : $this->Config()->Get('themes', 'default', $bMobile ? 'Mobile' : 'Default');
 	}
 
-	public function ValidateLanguage(string $sLanguage, string $sDefault = '', bool $bAdmin = false, bool $bAllowEmptyResult = false) : string
+	public function ValidateLanguage(string $sLanguage, string $sDefault = '', bool $bAdmin = false, bool $bAllowEmptyResult = false): string
 	{
 		$sResult = '';
 		$aLang = $this->GetLanguages($bAdmin);
@@ -2573,15 +2284,13 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		$sDefault = isset($aHelper[$sDefault]) ? $aHelper[$sDefault] : $sDefault;
 
 		$sLanguage = \strtolower(\str_replace('-', '_', $sLanguage));
-		if (2 === strlen($sLanguage))
-		{
-			$sLanguage = $sLanguage.'_'.$sLanguage;
+		if (2 === strlen($sLanguage)) {
+			$sLanguage = $sLanguage . '_' . $sLanguage;
 		}
 
 		$sDefault = \strtolower(\str_replace('-', '_', $sDefault));
-		if (2 === strlen($sDefault))
-		{
-			$sDefault = $sDefault.'_'.$sDefault;
+		if (2 === strlen($sDefault)) {
+			$sDefault = $sDefault . '_' . $sDefault;
 		}
 
 		$sLanguage = \preg_replace_callback('/_([a-zA-Z0-9]{2})$/', function ($aData) {
@@ -2592,18 +2301,15 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 			return \strtoupper($aData[0]);
 		}, $sDefault);
 
-		if (\in_array($sLanguage, $aLang))
-		{
+		if (\in_array($sLanguage, $aLang)) {
 			$sResult = $sLanguage;
 		}
 
-		if (empty($sResult) && !empty($sDefault) && \in_array($sDefault, $aLang))
-		{
+		if (empty($sResult) && !empty($sDefault) && \in_array($sDefault, $aLang)) {
 			$sResult = $sDefault;
 		}
 
-		if (empty($sResult) && !$bAllowEmptyResult)
-		{
+		if (empty($sResult) && !$bAllowEmptyResult) {
 			$sResult = $this->Config()->Get('webmail', $bAdmin ? 'language_admin' : 'language', 'en_US');
 			$sResult = \in_array($sResult, $aLang) ? $sResult : 'en_US';
 		}
@@ -2611,7 +2317,7 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $sResult;
 	}
 
-	public function ValidateContactPdoType(string $sType) : string
+	public function ValidateContactPdoType(string $sType): string
 	{
 		return \in_array($sType, array('mysql', 'pgsql', 'sqlite')) ? $sType : 'sqlite';
 	}
@@ -2619,46 +2325,33 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 	/**
 	 * @staticvar array $aCache
 	 */
-	public function GetThemes(bool $bMobile = false, bool $bIncludeMobile = true) : array
+	public function GetThemes(bool $bMobile = false, bool $bIncludeMobile = true): array
 	{
-		if ($bMobile)
-		{
+		if ($bMobile) {
 			return array('Mobile');
 		}
 
 		static $aCache = array('full' => null, 'mobile' => null);
-		if ($bIncludeMobile && \is_array($aCache['full']))
-		{
+		if ($bIncludeMobile && \is_array($aCache['full'])) {
 			return $aCache['full'];
-		}
-		else if ($bIncludeMobile && \is_array($aCache['mobile']))
-		{
+		} else if ($bIncludeMobile && \is_array($aCache['mobile'])) {
 			return $aCache['mobile'];
 		}
 
 		$bClear = false;
 		$bDefault = false;
 		$sList = array();
-		$sDir = APP_VERSION_ROOT_PATH.'themes';
-		if (\is_dir($sDir))
-		{
+		$sDir = APP_VERSION_ROOT_PATH . 'themes';
+		if (\is_dir($sDir)) {
 			$rDirH = \opendir($sDir);
-			if ($rDirH)
-			{
-				while (($sFile = \readdir($rDirH)) !== false)
-				{
-					if ('.' !== $sFile[0] && \is_dir($sDir.'/'.$sFile) && \file_exists($sDir.'/'.$sFile.'/styles.less'))
-					{
-						if ('Default' === $sFile)
-						{
+			if ($rDirH) {
+				while (($sFile = \readdir($rDirH)) !== false) {
+					if ('.' !== $sFile[0] && \is_dir($sDir . '/' . $sFile) && \file_exists($sDir . '/' . $sFile . '/styles.less')) {
+						if ('Default' === $sFile) {
 							$bDefault = true;
-						}
-						else if ('Clear' === $sFile)
-						{
+						} else if ('Clear' === $sFile) {
 							$bClear = true;
-						}
-						else if ($bIncludeMobile || 'Mobile' !== $sFile)
-						{
+						} else if ($bIncludeMobile || 'Mobile' !== $sFile) {
 							$sList[] = $sFile;
 						}
 					}
@@ -2667,17 +2360,13 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 			}
 		}
 
-		$sDir = APP_INDEX_ROOT_PATH.'themes'; // custom user themes
-		if (\is_dir($sDir))
-		{
+		$sDir = APP_INDEX_ROOT_PATH . 'themes'; // custom user themes
+		if (\is_dir($sDir)) {
 			$rDirH = \opendir($sDir);
-			if ($rDirH)
-			{
-				while (($sFile = \readdir($rDirH)) !== false)
-				{
-					if ('.' !== $sFile[0] && \is_dir($sDir.'/'.$sFile) && \file_exists($sDir.'/'.$sFile.'/styles.less'))
-					{
-						$sList[] = $sFile.'@custom';
+			if ($rDirH) {
+				while (($sFile = \readdir($rDirH)) !== false) {
+					if ('.' !== $sFile[0] && \is_dir($sDir . '/' . $sFile) && \file_exists($sDir . '/' . $sFile . '/styles.less')) {
+						$sList[] = $sFile . '@custom';
 					}
 				}
 
@@ -2688,13 +2377,11 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		$sList = \array_unique($sList);
 		\sort($sList);
 
-		if ($bDefault)
-		{
+		if ($bDefault) {
 			\array_unshift($sList, 'Default');
 		}
 
-		if ($bClear)
-		{
+		if ($bClear) {
 			\array_push($sList, 'Clear');
 		}
 
@@ -2705,31 +2392,25 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 	/**
 	 * @staticvar array $aCache
 	 */
-	public function GetLanguages(bool $bAdmin = false) : array
+	public function GetLanguages(bool $bAdmin = false): array
 	{
 		static $aCache = array();
-		$sDir = APP_VERSION_ROOT_PATH.'app/localization/'.($bAdmin ? 'admin' : 'webmail').'/';
+		$sDir = APP_VERSION_ROOT_PATH . 'app/localization/' . ($bAdmin ? 'admin' : 'webmail') . '/';
 
-		if (isset($aCache[$sDir]))
-		{
+		if (isset($aCache[$sDir])) {
 			return $aCache[$sDir];
 		}
 
 		$aTop = array();
 		$aList = array();
 
-		if (\is_dir($sDir))
-		{
+		if (\is_dir($sDir)) {
 			$rDirH = \opendir($sDir);
-			if ($rDirH)
-			{
-				while (($sFile = \readdir($rDirH)) !== false)
-				{
-					if ('.' !== $sFile[0] && \is_file($sDir.'/'.$sFile) && '.yml' === \substr($sFile, -4))
-					{
+			if ($rDirH) {
+				while (($sFile = \readdir($rDirH)) !== false) {
+					if ('.' !== $sFile[0] && \is_file($sDir . '/' . $sFile) && '.yml' === \substr($sFile, -4)) {
 						$sLang = \substr($sFile, 0, -4);
-						if (0 < \strlen($sLang) && 'always' !== $sLang && '_source.en' !== $sLang)
-						{
+						if (0 < \strlen($sLang) && 'always' !== $sLang && '_source.en' !== $sLang) {
 							\array_push($aList, $sLang);
 						}
 					}
@@ -2746,7 +2427,7 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $aCache[$sDir];
 	}
 
-	public function ProcessTemplate(string $sName, string $sHtml) : string
+	public function ProcessTemplate(string $sName, string $sHtml): string
 	{
 		$sHtml = $this->Plugins()->ProcessTemplate($sName, $sHtml);
 		$sHtml = \preg_replace('/\{\{INCLUDE\/([a-zA-Z]+)\/PLACE\}\}/', '', $sHtml);
@@ -2757,7 +2438,7 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return Utils::ClearHtmlOutput($sHtml);
 	}
 
-	public function SetActionParams(array $aCurrentActionParams, string $sMethodName = '') : self
+	public function SetActionParams(array $aCurrentActionParams, string $sMethodName = ''): self
 	{
 		$this->Plugins()->RunHook('filter.action-params', array($sMethodName, &$aCurrentActionParams));
 
@@ -2785,42 +2466,36 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return $this->aCurrentActionParams;
 	}
 
-	public function HasActionParam(string $sKey) : bool
+	public function HasActionParam(string $sKey): bool
 	{
 		return isset($this->aCurrentActionParams[$sKey]);
 	}
 
-	public function Location(string $sUrl) : void
+	public function Location(string $sUrl): void
 	{
-		$this->Logger()->Write('Location: '.$sUrl);
-		\header('Location: '.$sUrl);
+		$this->Logger()->Write('Location: ' . $sUrl);
+		\header('Location: ' . $sUrl);
 	}
 
-	public function GetLanguageAndTheme(bool $bAdmin = false, bool $bMobile = false) : array
+	public function GetLanguageAndTheme(bool $bAdmin = false, bool $bMobile = false): array
 	{
 		$sTheme = $this->Config()->Get('webmail', 'theme', 'Default');
 
-		if ($bAdmin)
-		{
+		if ($bAdmin) {
 			$sLanguage = $this->Config()->Get('webmail', 'language_admin', 'en');
-		}
-		else
-		{
+		} else {
 			$oAccount = $this->GetAccount();
 
 			$sLanguage = $this->Config()->Get('webmail', 'language', 'en');
 
-			if ($oAccount)
-			{
+			if ($oAccount) {
 				$oSettings = $this->SettingsProvider()->Load($oAccount);
-				if ($oSettings instanceof Settings)
-				{
+				if ($oSettings instanceof Settings) {
 					$sLanguage = $oSettings->GetConf('Language', $sLanguage);
 				}
 
 				$oSettingsLocal = $this->SettingsProvider(true)->Load($oAccount);
-				if ($oSettingsLocal instanceof Settings)
-				{
+				if ($oSettingsLocal instanceof Settings) {
 					$sTheme = $oSettingsLocal->GetConf('Theme', $sTheme);
 				}
 			}
@@ -2832,26 +2507,24 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return array($sLanguage, $sTheme);
 	}
 
-	public function StaticI18N(string $sKey) : string
+	public function StaticI18N(string $sKey): string
 	{
 		static $sLang = null;
 		static $aLang = null;
 
-		if (null === $sLang)
-		{
+		if (null === $sLang) {
 			$aList = $this->GetLanguageAndTheme();
 			$sLang = $aList[0];
 		}
 
-		if (null === $aLang)
-		{
+		if (null === $aLang) {
 			$sLang = $this->ValidateLanguage($sLang, 'en');
 
 			$aLang = array();
 //			Utils::ReadAndAddLang(APP_VERSION_ROOT_PATH.'app/i18n/langs.ini', $aLang);
 //			Utils::ReadAndAddLang(APP_VERSION_ROOT_PATH.'langs/'.$sLang.'.ini', $aLang);
-			Utils::ReadAndAddLang(APP_VERSION_ROOT_PATH.'app/localization/langs.yml', $aLang);
-			Utils::ReadAndAddLang(APP_VERSION_ROOT_PATH.'app/localization/webmail/'.$sLang.'.yml', $aLang);
+			Utils::ReadAndAddLang(APP_VERSION_ROOT_PATH . 'app/localization/langs.yml', $aLang);
+			Utils::ReadAndAddLang(APP_VERSION_ROOT_PATH . 'app/localization/webmail/' . $sLang . '.yml', $aLang);
 
 			$this->Plugins()->ReadLang($sLang, $aLang);
 		}
@@ -2859,9 +2532,9 @@ NewThemeLink IncludeCss TemplatesLink LangLink IncludeBackground PluginsLink Aut
 		return isset($aLang[$sKey]) ? $aLang[$sKey] : $sKey;
 	}
 
-	public function StaticPath(string $sPath) : string
+	public function StaticPath(string $sPath): string
 	{
-		return Utils::WebStaticPath().$sPath;
+		return Utils::WebStaticPath() . $sPath;
 	}
 
 }

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Actions/Accounts.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Actions/Accounts.php
@@ -2,11 +2,11 @@
 
 namespace RainLoop\Actions;
 
-use \RainLoop\Enumerations\Capa;
-use \RainLoop\Exceptions\ClientException;
-use \RainLoop\Model\Account;
-use \RainLoop\Model\Identity;
-use \RainLoop\Notifications;
+use RainLoop\Enumerations\Capa;
+use RainLoop\Exceptions\ClientException;
+use RainLoop\Model\Account;
+use RainLoop\Model\Identity;
+use RainLoop\Notifications;
 use RainLoop\Providers\Storage\Enumerations\StorageType;
 use function trim;
 
@@ -16,12 +16,11 @@ trait Accounts
 	/**
 	 * @throws \MailSo\Base\Exceptions\Exception
 	 */
-	public function DoAccountSetup() : array
+	public function DoAccountSetup(): array
 	{
 		$oAccount = $this->getAccountFromToken();
 
-		if (!$this->GetCapa(false, false, Capa::ADDITIONAL_ACCOUNTS, $oAccount))
-		{
+		if (!$this->GetCapa(false, false, Capa::ADDITIONAL_ACCOUNTS, $oAccount)) {
 			return $this->FalseResponse(__FUNCTION__);
 		}
 
@@ -31,15 +30,12 @@ trait Accounts
 
 		$sEmail = trim($this->GetActionParam('Email', ''));
 		$sPassword = $this->GetActionParam('Password', '');
-		$bNew = '1' === (string) $this->GetActionParam('New', '1');
+		$bNew = '1' === (string)$this->GetActionParam('New', '1');
 
 		$sEmail = \MailSo\Base\Utils::IdnToAscii($sEmail, true);
-		if ($bNew && ($oAccount->Email() === $sEmail || $sParentEmail === $sEmail || isset($aAccounts[$sEmail])))
-		{
+		if ($bNew && ($oAccount->Email() === $sEmail || $sParentEmail === $sEmail || isset($aAccounts[$sEmail]))) {
 			throw new ClientException(Notifications::AccountAlreadyExists);
-		}
-		else if (!$bNew && !isset($aAccounts[$sEmail]))
-		{
+		} else if (!$bNew && !isset($aAccounts[$sEmail])) {
 			throw new ClientException(Notifications::AccountDoesNotExist);
 		}
 
@@ -47,8 +43,7 @@ trait Accounts
 		$oNewAccount->SetParentEmail($sParentEmail);
 
 		$aAccounts[$oNewAccount->Email()] = $oNewAccount->GetAuthToken();
-		if (!$oAccount->IsAdditionalAccount())
-		{
+		if (!$oAccount->IsAdditionalAccount()) {
 			$aAccounts[$oAccount->Email()] = $oAccount->GetAuthToken();
 		}
 
@@ -59,12 +54,11 @@ trait Accounts
 	/**
 	 * @throws \MailSo\Base\Exceptions\Exception
 	 */
-	public function DoAccountDelete() : array
+	public function DoAccountDelete(): array
 	{
 		$oAccount = $this->getAccountFromToken();
 
-		if (!$this->GetCapa(false, false, Capa::ADDITIONAL_ACCOUNTS, $oAccount))
-		{
+		if (!$this->GetCapa(false, false, Capa::ADDITIONAL_ACCOUNTS, $oAccount)) {
 			return $this->FalseResponse(__FUNCTION__);
 		}
 
@@ -74,16 +68,13 @@ trait Accounts
 
 		$aAccounts = $this->GetAccounts($oAccount);
 
-		if (0 < \strlen($sEmailToDelete) && $sEmailToDelete !== $sParentEmail && isset($aAccounts[$sEmailToDelete]))
-		{
+		if (0 < \strlen($sEmailToDelete) && $sEmailToDelete !== $sParentEmail && isset($aAccounts[$sEmailToDelete])) {
 			unset($aAccounts[$sEmailToDelete]);
 
 			$oAccountToChange = null;
-			if ($oAccount->Email() === $sEmailToDelete && !empty($aAccounts[$sParentEmail]))
-			{
+			if ($oAccount->Email() === $sEmailToDelete && !empty($aAccounts[$sParentEmail])) {
 				$oAccountToChange = $this->GetAccountFromCustomToken($aAccounts[$sParentEmail], false, false);
-				if ($oAccountToChange)
-				{
+				if ($oAccountToChange) {
 					$this->AuthToken($oAccountToChange);
 				}
 			}
@@ -98,13 +89,12 @@ trait Accounts
 	/**
 	 * @throws \MailSo\Base\Exceptions\Exception
 	 */
-	public function DoIdentityUpdate() : array
+	public function DoIdentityUpdate(): array
 	{
 		$oAccount = $this->getAccountFromToken();
 
 		$oIdentity = new \RainLoop\Model\Identity();
-		if (!$oIdentity->FromJSON($this->GetActionParams(), true))
-		{
+		if (!$oIdentity->FromJSON($this->GetActionParams(), true)) {
 			throw new ClientException(Notifications::InvalidInputArgument);
 		}
 
@@ -115,18 +105,16 @@ trait Accounts
 	/**
 	 * @throws \MailSo\Base\Exceptions\Exception
 	 */
-	public function DoIdentityDelete() : array
+	public function DoIdentityDelete(): array
 	{
 		$oAccount = $this->getAccountFromToken();
 
-		if (!$this->GetCapa(false, false, Capa::IDENTITIES, $oAccount))
-		{
+		if (!$this->GetCapa(false, false, Capa::IDENTITIES, $oAccount)) {
 			return $this->FalseResponse(__FUNCTION__);
 		}
 
 		$sId = trim($this->GetActionParam('IdToDelete', ''));
-		if (empty($sId))
-		{
+		if (empty($sId)) {
 			throw new ClientException(Notifications::UnknownError);
 		}
 
@@ -137,15 +125,14 @@ trait Accounts
 	/**
 	 * @throws \MailSo\Base\Exceptions\Exception
 	 */
-	public function DoAccountsAndIdentitiesSortOrder() : array
+	public function DoAccountsAndIdentitiesSortOrder(): array
 	{
 		$oAccount = $this->getAccountFromToken();
 
 		$aAccounts = $this->GetActionParam('Accounts', null);
 		$aIdentities = $this->GetActionParam('Identities', null);
 
-		if (!\is_array($aAccounts) && !\is_array($aIdentities))
-		{
+		if (!\is_array($aAccounts) && !\is_array($aIdentities)) {
 			return $this->FalseResponse(__FUNCTION__);
 		}
 
@@ -161,19 +148,17 @@ trait Accounts
 	/**
 	 * @throws \MailSo\Base\Exceptions\Exception
 	 */
-	public function DoAccountsAndIdentities() : array
+	public function DoAccountsAndIdentities(): array
 	{
 		$oAccount = $this->getAccountFromToken();
 
 		$mAccounts = false;
 
-		if ($this->GetCapa(false, false, Capa::ADDITIONAL_ACCOUNTS, $oAccount))
-		{
+		if ($this->GetCapa(false, false, Capa::ADDITIONAL_ACCOUNTS, $oAccount)) {
 			$mAccounts = $this->GetAccounts($oAccount);
 			$mAccounts = \array_keys($mAccounts);
 
-			foreach ($mAccounts as $iIndex => $sName)
-			{
+			foreach ($mAccounts as $iIndex => $sName) {
 				$mAccounts[$iIndex] = \MailSo\Base\Utils::IdnToUtf8($sName);
 			}
 		}
@@ -184,35 +169,35 @@ trait Accounts
 		));
 	}
 
-    /**
-     * @param Account $account
-     * @return Identity[]
-     */
-    public function GetIdentities(Account $account) : array
-    {
-        if(!$account) return [];
+	/**
+	 * @param Account $account
+	 * @return Identity[]
+	 */
+	public function GetIdentities(Account $account): array
+	{
+		if (!$account) return [];
 
-        // A custom name for a single identity is also stored in this system
-        $allowMultipleIdentities = $this->GetCapa(false, false, Capa::IDENTITIES, $account);
+		// A custom name for a single identity is also stored in this system
+		$allowMultipleIdentities = $this->GetCapa(false, false, Capa::IDENTITIES, $account);
 
-        // Get all identities
-        $identities = $this->IdentitiesProvider()->GetIdentities($account, $allowMultipleIdentities);
+		// Get all identities
+		$identities = $this->IdentitiesProvider()->GetIdentities($account, $allowMultipleIdentities);
 
-        // Sort identities
-        $orderString = $this->StorageProvider()->Get($account, StorageType::CONFIG, 'accounts_identities_order');
-        $order = json_decode($orderString, true) ?? [];
-        if(isset($order['Identities']) && is_array($order['Identities']) && count($order['Identities']) > 1) {
-            $list = array_map(function($item) {
-                if('' === $item) $item = '---';
-                return $item;
-            }, $order['Identities']);
+		// Sort identities
+		$orderString = $this->StorageProvider()->Get($account, StorageType::CONFIG, 'accounts_identities_order');
+		$order = json_decode($orderString, true) ?? [];
+		if (isset($order['Identities']) && is_array($order['Identities']) && count($order['Identities']) > 1) {
+			$list = array_map(function ($item) {
+				if ('' === $item) $item = '---';
+				return $item;
+			}, $order['Identities']);
 
-            usort($identities, function($a, $b) use ($list) {
-                return array_search($a->Id(true), $list) < array_search($b->Id(true), $list) ? -1 : 1;
-            });
-        }
+			usort($identities, function ($a, $b) use ($list) {
+				return array_search($a->Id(true), $list) < array_search($b->Id(true), $list) ? -1 : 1;
+			});
+		}
 
-        return $identities;
-    }
+		return $identities;
+	}
 
 }

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Model/Identity.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Model/Identity.php
@@ -7,40 +7,40 @@ use MailSo\Base\Utils;
 
 class Identity implements JsonSerializable
 {
-    /**
-     * @var string
-     */
-    private $sId;
+	/**
+	 * @var string
+	 */
+	private $sId;
 
-    /**
-     * @var string
-     */
-    private $sEmail;
+	/**
+	 * @var string
+	 */
+	private $sEmail;
 
-    /**
-     * @var string
-     */
-    private $sName;
+	/**
+	 * @var string
+	 */
+	private $sName;
 
-    /**
-     * @var string
-     */
-    private $sReplyTo;
+	/**
+	 * @var string
+	 */
+	private $sReplyTo;
 
-    /**
-     * @var string
-     */
-    private $sBcc;
+	/**
+	 * @var string
+	 */
+	private $sBcc;
 
-    /**
-     * @var string
-     */
-    private $sSignature;
+	/**
+	 * @var string
+	 */
+	private $sSignature;
 
-    /**
-     * @var bool
-     */
-    private $bSignatureInsertBefore;
+	/**
+	 * @var bool
+	 */
+	private $bSignatureInsertBefore;
 
 	function __construct(string $sId = '', string $sEmail = '')
 	{
@@ -53,88 +53,87 @@ class Identity implements JsonSerializable
 		$this->bSignatureInsertBefore = false;
 	}
 
-	public function Id(bool $bFillOnEmpty = false) : string
+	public function Id(bool $bFillOnEmpty = false): string
 	{
 		return $bFillOnEmpty ? ('' === $this->sId ? '---' : $this->sId) : $this->sId;
 	}
 
-	public function Email() : string
+	public function Email(): string
 	{
 		return $this->sEmail;
 	}
 
-	public function SetEmail(string $sEmail) : self
+	public function SetEmail(string $sEmail): self
 	{
 		$this->sEmail = $sEmail;
 
 		return $this;
 	}
 
-	public function Name() : string
+	public function Name(): string
 	{
 		return $this->sName;
 	}
 
-	public function ReplyTo() : string
+	public function ReplyTo(): string
 	{
 		return $this->sReplyTo;
 	}
 
-	public function Bcc() : string
+	public function Bcc(): string
 	{
 		return $this->sBcc;
 	}
 
-	public function Signature() : string
+	public function Signature(): string
 	{
 		return $this->sSignature;
 	}
 
-	public function SignatureInsertBefore() : bool
+	public function SignatureInsertBefore(): bool
 	{
 		return $this->bSignatureInsertBefore;
 	}
 
-    public function SetId(string $sId): Identity
-    {
-        $this->sId = $sId;
-        return $this;
-    }
-
-    public function SetName(string $sName): Identity
-    {
-        $this->sName = $sName;
-        return $this;
-    }
-
-    public function SetReplyTo(string $sReplyTo): Identity
-    {
-        $this->sReplyTo = $sReplyTo;
-        return $this;
-    }
-
-    public function SetBcc(string $sBcc): Identity
-    {
-        $this->sBcc = $sBcc;
-        return $this;
-    }
-
-    public function SetSignature(string $sSignature): Identity
-    {
-        $this->sSignature = $sSignature;
-        return $this;
-    }
-
-    public function SetSignatureInsertBefore(bool $bSignatureInsertBefore): Identity
-    {
-        $this->bSignatureInsertBefore = $bSignatureInsertBefore;
-        return $this;
-    }
-
-	public function FromJSON(array $aData, bool $bAjax = false) : bool
+	public function SetId(string $sId): Identity
 	{
-		if (!empty($aData['Email']))
-		{
+		$this->sId = $sId;
+		return $this;
+	}
+
+	public function SetName(string $sName): Identity
+	{
+		$this->sName = $sName;
+		return $this;
+	}
+
+	public function SetReplyTo(string $sReplyTo): Identity
+	{
+		$this->sReplyTo = $sReplyTo;
+		return $this;
+	}
+
+	public function SetBcc(string $sBcc): Identity
+	{
+		$this->sBcc = $sBcc;
+		return $this;
+	}
+
+	public function SetSignature(string $sSignature): Identity
+	{
+		$this->sSignature = $sSignature;
+		return $this;
+	}
+
+	public function SetSignatureInsertBefore(bool $bSignatureInsertBefore): Identity
+	{
+		$this->bSignatureInsertBefore = $bSignatureInsertBefore;
+		return $this;
+	}
+
+	public function FromJSON(array $aData, bool $bAjax = false): bool
+	{
+		if (!empty($aData['Email'])) {
 			$this->sId = !empty($aData['Id']) ? $aData['Id'] : '';
 			$this->sEmail = $bAjax ? Utils::IdnToAscii($aData['Email'], true) : $aData['Email'];
 			$this->sName = isset($aData['Name']) ? $aData['Name'] : '';
@@ -150,7 +149,7 @@ class Identity implements JsonSerializable
 		return false;
 	}
 
-	public function ToSimpleJSON() : array
+	public function ToSimpleJSON(): array
 	{
 		return array(
 			'Id' => $this->Id(),
@@ -176,12 +175,12 @@ class Identity implements JsonSerializable
 		);
 	}
 
-	public function Validate() : bool
+	public function Validate(): bool
 	{
 		return !empty($this->sEmail);
 	}
 
-	public function IsAccountIdentities() : bool
+	public function IsAccountIdentities(): bool
 	{
 		return '' === $this->Id();
 	}

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Model/Identity.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Model/Identity.php
@@ -2,42 +2,45 @@
 
 namespace RainLoop\Model;
 
-class Identity implements \JsonSerializable
+use JsonSerializable;
+use MailSo\Base\Utils;
+
+class Identity implements JsonSerializable
 {
-	/**
-	 * @var string
-	 */
-	private $sId;
+    /**
+     * @var string
+     */
+    private $sId;
 
-	/**
-	 * @var string
-	 */
-	private $sEmail;
+    /**
+     * @var string
+     */
+    private $sEmail;
 
-	/**
-	 * @var string
-	 */
-	private $sName;
+    /**
+     * @var string
+     */
+    private $sName;
 
-	/**
-	 * @var string
-	 */
-	private $sReplyTo;
+    /**
+     * @var string
+     */
+    private $sReplyTo;
 
-	/**
-	 * @var string
-	 */
-	private $sBcc;
+    /**
+     * @var string
+     */
+    private $sBcc;
 
-	/**
-	 * @var string
-	 */
-	private $sSignature;
+    /**
+     * @var string
+     */
+    private $sSignature;
 
-	/**
-	 * @var bool
-	 */
-	private $bSignatureInsertBefore;
+    /**
+     * @var bool
+     */
+    private $bSignatureInsertBefore;
 
 	function __construct(string $sId = '', string $sEmail = '')
 	{
@@ -92,12 +95,48 @@ class Identity implements \JsonSerializable
 		return $this->bSignatureInsertBefore;
 	}
 
+    public function SetId(string $sId): Identity
+    {
+        $this->sId = $sId;
+        return $this;
+    }
+
+    public function SetName(string $sName): Identity
+    {
+        $this->sName = $sName;
+        return $this;
+    }
+
+    public function SetReplyTo(string $sReplyTo): Identity
+    {
+        $this->sReplyTo = $sReplyTo;
+        return $this;
+    }
+
+    public function SetBcc(string $sBcc): Identity
+    {
+        $this->sBcc = $sBcc;
+        return $this;
+    }
+
+    public function SetSignature(string $sSignature): Identity
+    {
+        $this->sSignature = $sSignature;
+        return $this;
+    }
+
+    public function SetSignatureInsertBefore(bool $bSignatureInsertBefore): Identity
+    {
+        $this->bSignatureInsertBefore = $bSignatureInsertBefore;
+        return $this;
+    }
+
 	public function FromJSON(array $aData, bool $bAjax = false) : bool
 	{
 		if (!empty($aData['Email']))
 		{
 			$this->sId = !empty($aData['Id']) ? $aData['Id'] : '';
-			$this->sEmail = $bAjax ? \MailSo\Base\Utils::IdnToAscii($aData['Email'], true) : $aData['Email'];
+			$this->sEmail = $bAjax ? Utils::IdnToAscii($aData['Email'], true) : $aData['Email'];
 			$this->sName = isset($aData['Name']) ? $aData['Name'] : '';
 			$this->sReplyTo = !empty($aData['ReplyTo']) ? $aData['ReplyTo'] : '';
 			$this->sBcc = !empty($aData['Bcc']) ? $aData['Bcc'] : '';
@@ -127,9 +166,8 @@ class Identity implements \JsonSerializable
 	public function jsonSerialize()
 	{
 		return array(
-//			'@Object' => 'Object/Identity',
 			'Id' => $this->Id(),
-			'Email' => \MailSo\Base\Utils::IdnToUtf8($this->Email()),
+			'Email' => Utils::IdnToUtf8($this->Email()),
 			'Name' => $this->Name(),
 			'ReplyTo' => $this->ReplyTo(),
 			'Bcc' => $this->Bcc(),

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities.php
@@ -8,127 +8,132 @@ use RainLoop\Providers\Identities\IIdentities;
 
 class Identities extends AbstractProvider
 {
-    /** @var IIdentities[] */
-    private $drivers;
+	/** @var IIdentities[] */
+	private $drivers;
 
-    /** @var Identity[][][] */
-    private $identitiesPerDriverPerAccount;
+	/** @var Identity[][][] */
+	private $identitiesPerDriverPerAccount;
 
-    /**
-     * Identities constructor.
-     * @param IIdentities[] $drivers
-     */
-    public function __construct(?array $drivers = null)
-    {
-        if($drivers === null) $drivers = [];
+	/**
+	 * Identities constructor.
+	 * @param IIdentities[] $drivers
+	 */
+	public function __construct(?array $drivers = null)
+	{
+		if ($drivers === null) $drivers = [];
 
-        $this->drivers = array_filter($drivers, function($driver) {
-            return $driver instanceof IIdentities;
-        });
-    }
+		$this->drivers = array_filter($drivers, function ($driver) {
+			return $driver instanceof IIdentities;
+		});
+	}
 
-    /**
-     * @param Account $account
-     * @param bool $allowMultipleIdentities
-     * @return Identity[]
-     */
-    public function GetIdentities(Account $account, bool $allowMultipleIdentities) : array {
-        // Find all identities stored in the system
-        $identities = $this->MergeIdentitiesPerDriver($this->GetIdentiesPerDriver($account));
+	/**
+	 * @param Account $account
+	 * @param bool $allowMultipleIdentities
+	 * @return Identity[]
+	 */
+	public function GetIdentities(Account $account, bool $allowMultipleIdentities): array
+	{
+		// Find all identities stored in the system
+		$identities = $this->MergeIdentitiesPerDriver($this->GetIdentiesPerDriver($account));
 
-        // Find the primary identity
-        $primaryIdentity = current(array_filter($identities, function($identity) {
-            return $identity->IsAccountIdentities();
-        }));
+		// Find the primary identity
+		$primaryIdentity = current(array_filter($identities, function ($identity) {
+			return $identity->IsAccountIdentities();
+		}));
 
-        // If no primary identity is found, generate default one from account info
-        if($primaryIdentity === null || $primaryIdentity === false)
-            $identities[] = $primaryIdentity = new Identity('', $account->Email());
+		// If no primary identity is found, generate default one from account info
+		if ($primaryIdentity === null || $primaryIdentity === false)
+			$identities[] = $primaryIdentity = new Identity('', $account->Email());
 
-        // Return only primary identity or all identities
-        return $allowMultipleIdentities ? $identities : [$primaryIdentity];
-    }
+		// Return only primary identity or all identities
+		return $allowMultipleIdentities ? $identities : [$primaryIdentity];
+	}
 
-    public function UpdateIdentity(Account $account, Identity $identity) {
-        // Find all identities in the system
-        $identities = &$this->GetIdentiesPerDriver($account);
+	public function UpdateIdentity(Account $account, Identity $identity)
+	{
+		// Find all identities in the system
+		$identities = &$this->GetIdentiesPerDriver($account);
 
-        $isNew = true;
-        foreach($this->drivers as $driver) {
-            if(!$driver->SupportsStore()) continue;
+		$isNew = true;
+		foreach ($this->drivers as $driver) {
+			if (!$driver->SupportsStore()) continue;
 
-            $driverIdentities = &$identities[$driver->Name()];
-            if(!isset($driverIdentities[$identity->Id(true)]))
-                continue;
+			$driverIdentities = &$identities[$driver->Name()];
+			if (!isset($driverIdentities[$identity->Id(true)]))
+				continue;
 
-            // We update the identity in all writeable stores
-            $driverIdentities[$identity->Id(true)] = $identity;
-            $isNew = false;
+			// We update the identity in all writeable stores
+			$driverIdentities[$identity->Id(true)] = $identity;
+			$isNew = false;
 
-            $driver->SetIdentities($account, $driverIdentities);
-        }
+			$driver->SetIdentities($account, $driverIdentities);
+		}
 
-        // If it is a new identity we add it to any storage driver
-        if($isNew) {
-            // Pick any storage driver to store the result, typically only file storage
-            $storageDriver = current(array_filter($this->drivers, function($driver) {
-                return $driver->SupportsStore();
-            }));
+		// If it is a new identity we add it to any storage driver
+		if ($isNew) {
+			// Pick any storage driver to store the result, typically only file storage
+			$storageDriver = current(array_filter($this->drivers, function ($driver) {
+				return $driver->SupportsStore();
+			}));
 
-            $identities[$storageDriver->Name()][$identity->Id(true)] = $identity;
-            $storageDriver->SetIdentities($account, $identities[$storageDriver->Name()]);
-        }
-    }
+			$identities[$storageDriver->Name()][$identity->Id(true)] = $identity;
+			$storageDriver->SetIdentities($account, $identities[$storageDriver->Name()]);
+		}
+	}
 
-    public function DeleteIdentity(Account $account, string $identityId) {
-        // On deletion, we remove the identity from all drivers if they are writeable.
-        $identities = &$this->GetIdentiesPerDriver($account);
+	public function DeleteIdentity(Account $account, string $identityId)
+	{
+		// On deletion, we remove the identity from all drivers if they are writeable.
+		$identities = &$this->GetIdentiesPerDriver($account);
 
-        foreach($this->drivers as $driver) {
-            if(!$driver->SupportsStore()) continue;
+		foreach ($this->drivers as $driver) {
+			if (!$driver->SupportsStore()) continue;
 
-            $driverIdentities = &$identities[$driver->Name()];
-            if(!isset($driverIdentities[$identityId]))
-                continue;
+			$driverIdentities = &$identities[$driver->Name()];
+			if (!isset($driverIdentities[$identityId]))
+				continue;
 
-            // We found it, so remove and update storage if relevant
-            $identity = $driverIdentities[$identityId];
-            if($identity->IsAccountIdentities()) continue; // never remove the primary identity
+			// We found it, so remove and update storage if relevant
+			$identity = $driverIdentities[$identityId];
+			if ($identity->IsAccountIdentities()) continue; // never remove the primary identity
 
-            unset($driverIdentities[$identityId]);
-            $driver->SetIdentities($account, $driverIdentities);
-        }
-    }
+			unset($driverIdentities[$identityId]);
+			$driver->SetIdentities($account, $driverIdentities);
+		}
+	}
 
-    private function &GetIdentiesPerDriver(Account $account) : array {
-        if(isset($this->identitiesPerDriverPerAccount[$account->Email()]))
-            return $this->identitiesPerDriverPerAccount[$account->Email()];
+	private function &GetIdentiesPerDriver(Account $account): array
+	{
+		if (isset($this->identitiesPerDriverPerAccount[$account->Email()]))
+			return $this->identitiesPerDriverPerAccount[$account->Email()];
 
-        $identitiesPerDriver = [];
-        foreach($this->drivers as $driver) {
-            $driverIdentities = $driver->GetIdentities($account);
+		$identitiesPerDriver = [];
+		foreach ($this->drivers as $driver) {
+			$driverIdentities = $driver->GetIdentities($account);
 
-            foreach($driverIdentities as $identity)
-                $identitiesPerDriver[$driver->Name()][$identity->Id(true)] = $identity;
-        }
+			foreach ($driverIdentities as $identity)
+				$identitiesPerDriver[$driver->Name()][$identity->Id(true)] = $identity;
+		}
 
-        $this->identitiesPerDriverPerAccount[$account->Email()] = $identitiesPerDriver;
-        return $this->identitiesPerDriverPerAccount[$account->Email()];
-    }
+		$this->identitiesPerDriverPerAccount[$account->Email()] = $identitiesPerDriver;
+		return $this->identitiesPerDriverPerAccount[$account->Email()];
+	}
 
-    /**
-     * @param Identity[][] $identitiesPerDriver
-     * @return Identity[]
-     */
-    private function MergeIdentitiesPerDriver(array $identitiesPerDriver) : array {
-        // Merge logic for the identities
-        $identities = [];
-        foreach($this->drivers as $driver) {
-            // Merge and replace by key
-            foreach($identitiesPerDriver[$driver->Name()] as $identity)
-                $identities[$identity->Id(true)] = $identity;
-        }
+	/**
+	 * @param Identity[][] $identitiesPerDriver
+	 * @return Identity[]
+	 */
+	private function MergeIdentitiesPerDriver(array $identitiesPerDriver): array
+	{
+		// Merge logic for the identities
+		$identities = [];
+		foreach ($this->drivers as $driver) {
+			// Merge and replace by key
+			foreach ($identitiesPerDriver[$driver->Name()] as $identity)
+				$identities[$identity->Id(true)] = $identity;
+		}
 
-        return array_values($identities);
-    }
+		return array_values($identities);
+	}
 }

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace RainLoop\Providers;
+
+use RainLoop\Model\Account;
+use RainLoop\Model\Identity;
+use RainLoop\Providers\Identities\IIdentities;
+
+class Identities extends AbstractProvider
+{
+    /** @var IIdentities[] */
+    private $drivers;
+
+    /** @var Identity[][][] */
+    private $identitiesPerDriverPerAccount;
+
+    /**
+     * Identities constructor.
+     * @param IIdentities[] $drivers
+     */
+    public function __construct(?array $drivers = null)
+    {
+        if($drivers === null) $drivers = [];
+
+        $this->drivers = array_filter($drivers, function($driver) {
+            return $driver instanceof IIdentities;
+        });
+    }
+
+    /**
+     * @param Account $account
+     * @param bool $allowMultipleIdentities
+     * @return Identity[]
+     */
+    public function GetIdentities(Account $account, bool $allowMultipleIdentities) : array {
+        // Find all identities stored in the system
+        $identities = $this->MergeIdentitiesPerDriver($this->GetIdentiesPerDriver($account));
+
+        file_put_contents('php://stderr', print_r($this->identitiesPerDriverPerAccount, TRUE));
+
+        // Find the primary identity
+        $primaryIdentity = array_filter($identities, function($identity) {
+            return $identity->IsAccountIdentities();
+        })[0];
+
+        // If no primary identity is found, generate default one from account info
+        if($primaryIdentity === null)
+            $identities[] = $primaryIdentity = new Identity('', $account->Email());
+
+        // Return only primary identity or all identities
+        return $allowMultipleIdentities ? $identities : [$primaryIdentity];
+    }
+
+    public function UpdateIdentity(Account $account, Identity $identity) {
+        // Find all identities in the system
+        $identities = &$this->GetIdentiesPerDriver($account);
+
+        $isNew = true;
+        foreach($this->drivers as $driver) {
+            if(!$driver->SupportsStore()) continue;
+
+            $driverIdentities = &$identities[$driver->Name()];
+            if(!isset($driverIdentities[$identity->Id(true)]))
+                continue;
+
+            // We update the identity in all writeable stores
+            $driverIdentities[$identity->Id(true)] = $identity;
+            $isNew = false;
+
+            $driver->SetIdentities($account, $driverIdentities);
+        }
+
+        // If it is a new identity we add it to any storage driver
+        if($isNew) {
+            // Pick any storage driver to store the result, typically only file storage
+            $storageDriver = array_filter($this->drivers, function($driver) {
+                return $driver->SupportsStore();
+            })[0];
+
+            $identities[$storageDriver->Name()][$identity->Id(true)] = $identity;
+            $storageDriver->SetIdentities($account, $identities[$storageDriver->Name()]);
+        }
+    }
+
+    public function DeleteIdentity(Account $account, string $identityId) {
+        // On deletion, we remove the identity from all drivers if they are writeable.
+        $identities = &$this->GetIdentiesPerDriver($account);
+
+        foreach($this->drivers as $driver) {
+            if(!$driver->SupportsStore()) continue;
+
+            $driverIdentities = &$identities[$driver->Name()];
+            if(!isset($driverIdentities[$identityId]))
+                continue;
+
+            // We found it, so remove and update storage if relevant
+            $identity = $driverIdentities[$identityId];
+            if($identity->IsAccountIdentities()) continue; // never remove the primary identity
+
+            unset($driverIdentities[$identityId]);
+            $driver->SetIdentities($account, $driverIdentities);
+        }
+    }
+
+    private function &GetIdentiesPerDriver(Account $account) : array {
+        if(isset($this->identitiesPerDriverPerAccount[$account->Email()]))
+            return $this->identitiesPerDriverPerAccount[$account->Email()];
+
+        $identitiesPerDriver = [];
+        foreach($this->drivers as $driver) {
+            $driverIdentities = $driver->GetIdentities($account);
+
+            foreach($driverIdentities as $identity)
+                $identitiesPerDriver[$driver->Name()][$identity->Id(true)] = $identity;
+        }
+
+        $this->identitiesPerDriverPerAccount[$account->Email()] = $identitiesPerDriver;
+        return $this->identitiesPerDriverPerAccount[$account->Email()];
+    }
+
+    /**
+     * @param Identity[][] $identitiesPerDriver
+     * @return Identity[]
+     */
+    private function MergeIdentitiesPerDriver(array $identitiesPerDriver) : array {
+        // Merge logic for the identities
+        $identities = [];
+        foreach($this->drivers as $driver) {
+            // Merge and replace by key
+            foreach($identitiesPerDriver[$driver->Name()] as $identity)
+                $identities[$identity->Id(true)] = $identity;
+        }
+
+        return array_values($identities);
+    }
+}

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities.php
@@ -36,15 +36,13 @@ class Identities extends AbstractProvider
         // Find all identities stored in the system
         $identities = $this->MergeIdentitiesPerDriver($this->GetIdentiesPerDriver($account));
 
-        file_put_contents('php://stderr', print_r($this->identitiesPerDriverPerAccount, TRUE));
-
         // Find the primary identity
-        $primaryIdentity = array_filter($identities, function($identity) {
+        $primaryIdentity = current(array_filter($identities, function($identity) {
             return $identity->IsAccountIdentities();
-        })[0];
+        }));
 
         // If no primary identity is found, generate default one from account info
-        if($primaryIdentity === null)
+        if($primaryIdentity === null || $primaryIdentity === false)
             $identities[] = $primaryIdentity = new Identity('', $account->Email());
 
         // Return only primary identity or all identities
@@ -73,9 +71,9 @@ class Identities extends AbstractProvider
         // If it is a new identity we add it to any storage driver
         if($isNew) {
             // Pick any storage driver to store the result, typically only file storage
-            $storageDriver = array_filter($this->drivers, function($driver) {
+            $storageDriver = current(array_filter($this->drivers, function($driver) {
                 return $driver->SupportsStore();
-            })[0];
+            }));
 
             $identities[$storageDriver->Name()][$identity->Id(true)] = $identity;
             $storageDriver->SetIdentities($account, $identities[$storageDriver->Name()]);

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities/FileIdentities.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities/FileIdentities.php
@@ -8,62 +8,64 @@ use RainLoop\Providers\Storage;
 
 class FileIdentities implements IIdentities
 {
-    /**
-     * @var Storage
-     */
-    private $localStorageProvider;
+	/**
+	 * @var Storage
+	 */
+	private $localStorageProvider;
 
-    /**
-     * FileIdentities constructor.
-     * @param Storage $localStorageProvider
-     */
-    public function __construct(Storage $localStorageProvider)
-    {
-        $this->localStorageProvider = $localStorageProvider;
-    }
+	/**
+	 * FileIdentities constructor.
+	 * @param Storage $localStorageProvider
+	 */
+	public function __construct(Storage $localStorageProvider)
+	{
+		$this->localStorageProvider = $localStorageProvider;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function GetIdentities(Account $account): array
-    {
-        if(!$account) return [];
+	/**
+	 * @inheritDoc
+	 */
+	public function GetIdentities(Account $account): array
+	{
+		if (!$account) return [];
 
-        $data = $this->localStorageProvider->Get($account, Storage\Enumerations\StorageType::CONFIG, 'identities');
-        $subIdentities = json_decode($data, true) ?? [];
-        $result = [];
+		$data = $this->localStorageProvider->Get($account, Storage\Enumerations\StorageType::CONFIG, 'identities');
+		$subIdentities = json_decode($data, true) ?? [];
+		$result = [];
 
-        foreach($subIdentities as $subIdentity) {
-            $identity = new Identity();
-            $identity->FromJSON($subIdentity);
+		foreach ($subIdentities as $subIdentity) {
+			$identity = new Identity();
+			$identity->FromJSON($subIdentity);
 
-            if(!$identity->Validate()) continue;
-            if($identity->IsAccountIdentities()) $identity->SetEmail($account->Email());
-            $result[] = $identity;
-        }
+			if (!$identity->Validate()) continue;
+			if ($identity->IsAccountIdentities()) $identity->SetEmail($account->Email());
+			$result[] = $identity;
+		}
 
-        return $result;
-    }
+		return $result;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function SetIdentities(Account $account, array $identities)
-    {
-        $jsons = array_map(function($identity) { return $identity->ToSimpleJSON(); }, $identities);
-        $this->localStorageProvider->Put($account, Storage\Enumerations\StorageType::CONFIG, 'identities', json_encode($jsons));
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function SetIdentities(Account $account, array $identities)
+	{
+		$jsons = array_map(function ($identity) {
+			return $identity->ToSimpleJSON();
+		}, $identities);
+		$this->localStorageProvider->Put($account, Storage\Enumerations\StorageType::CONFIG, 'identities', json_encode($jsons));
+	}
 
-    /**
-     * @inheritDoc
-     */
-    public function SupportsStore() : bool
-    {
-        return true;
-    }
+	/**
+	 * @inheritDoc
+	 */
+	public function SupportsStore(): bool
+	{
+		return true;
+	}
 
-    public function Name(): string
-    {
-        return "File";
-    }
+	public function Name(): string
+	{
+		return "File";
+	}
 }

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities/FileIdentities.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities/FileIdentities.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace RainLoop\Providers\Identities;
+
+use RainLoop\Model\Account;
+use RainLoop\Model\Identity;
+use RainLoop\Providers\Storage;
+
+class FileIdentities implements IIdentities
+{
+    /**
+     * @var Storage
+     */
+    private $localStorageProvider;
+
+    /**
+     * FileIdentities constructor.
+     * @param Storage $localStorageProvider
+     */
+    public function __construct(Storage $localStorageProvider)
+    {
+        $this->localStorageProvider = $localStorageProvider;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function GetIdentities(Account $account): array
+    {
+        if(!$account) return [];
+
+        $data = $this->localStorageProvider->Get($account, Storage\Enumerations\StorageType::CONFIG, 'identities');
+        $subIdentities = json_decode($data, true) ?? [];
+        $result = [];
+
+        foreach($subIdentities as $subIdentity) {
+            $identity = new Identity();
+            $identity->FromJSON($subIdentity);
+
+            if(!$identity->Validate()) continue;
+            if($identity->IsAccountIdentities()) $identity->SetEmail($account->Email());
+            $result[] = $identity;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function SetIdentities(Account $account, array $identities)
+    {
+        $jsons = array_map(function($identity) { return $identity->ToSimpleJSON(); }, $identities);
+        $this->localStorageProvider->Put($account, Storage\Enumerations\StorageType::CONFIG, 'identities', json_encode($jsons));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function SupportsStore() : bool
+    {
+        return true;
+    }
+
+    public function Name(): string
+    {
+        return "File";
+    }
+}

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities/IIdentities.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities/IIdentities.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace RainLoop\Providers\Identities;
+
+use RainLoop\Model\Account;
+use RainLoop\Model\Identity;
+
+interface IIdentities
+{
+    /**
+     * @param Account $account
+     * 
+     * @return Identity[]
+     */
+    public function GetIdentities(Account $account) : array;
+
+    /**
+     * @param Account $account
+     * @param Identity[] $identities
+     * 
+     * @return void
+     */
+    public function SetIdentities(Account $account, array $identities);
+
+    /**
+     * @return bool
+     */
+    public function SupportsStore() : bool;
+
+    /**
+     * @return string
+     */
+    public function Name() : string;
+}

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities/IIdentities.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities/IIdentities.php
@@ -7,28 +7,28 @@ use RainLoop\Model\Identity;
 
 interface IIdentities
 {
-    /**
-     * @param Account $account
-     * 
-     * @return Identity[]
-     */
-    public function GetIdentities(Account $account) : array;
+	/**
+	 * @param Account $account
+	 *
+	 * @return Identity[]
+	 */
+	public function GetIdentities(Account $account): array;
 
-    /**
-     * @param Account $account
-     * @param Identity[] $identities
-     * 
-     * @return void
-     */
-    public function SetIdentities(Account $account, array $identities);
+	/**
+	 * @param Account $account
+	 * @param Identity[] $identities
+	 *
+	 * @return void
+	 */
+	public function SetIdentities(Account $account, array $identities);
 
-    /**
-     * @return bool
-     */
-    public function SupportsStore() : bool;
+	/**
+	 * @return bool
+	 */
+	public function SupportsStore(): bool;
 
-    /**
-     * @return string
-     */
-    public function Name() : string;
+	/**
+	 * @return string
+	 */
+	public function Name(): string;
 }

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities/TestIdentities.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities/TestIdentities.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace RainLoop\Providers\Identities;
+
+use RainLoop\Exceptions\Exception;
+use RainLoop\Model\Account;
+use RainLoop\Model\Identity;
+
+class TestIdentities implements IIdentities
+{
+    /**
+     * @param Account $account
+     * @return Identity[]
+     */
+    public function GetIdentities(Account $account): array
+    {
+        $oIdentity = new Identity('', $account->Email());
+        $oIdentity->SetName("Test Name");
+
+        return [$oIdentity];
+    }
+
+    /**
+     * @param Account $account
+     * @param Identity[] $identities
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function SetIdentities(Account $account, array $identities)
+    {
+        throw new Exception("Not implemented");
+    }
+
+    /**
+     * @return bool
+     */
+    public function SupportsStore() : bool
+    {
+        return false;
+    }
+
+    public function Name() : string { return "Test"; }
+}

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities/TestIdentities.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Identities/TestIdentities.php
@@ -8,37 +8,40 @@ use RainLoop\Model\Identity;
 
 class TestIdentities implements IIdentities
 {
-    /**
-     * @param Account $account
-     * @return Identity[]
-     */
-    public function GetIdentities(Account $account): array
-    {
-        $oIdentity = new Identity('', $account->Email());
-        $oIdentity->SetName("Test Name");
+	/**
+	 * @param Account $account
+	 * @return Identity[]
+	 */
+	public function GetIdentities(Account $account): array
+	{
+		$oIdentity = new Identity('', $account->Email());
+		$oIdentity->SetName("Test Name");
 
-        return [$oIdentity];
-    }
+		return [$oIdentity];
+	}
 
-    /**
-     * @param Account $account
-     * @param Identity[] $identities
-     *
-     * @return void
-     * @throws Exception
-     */
-    public function SetIdentities(Account $account, array $identities)
-    {
-        throw new Exception("Not implemented");
-    }
+	/**
+	 * @param Account $account
+	 * @param Identity[] $identities
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function SetIdentities(Account $account, array $identities)
+	{
+		throw new Exception("Not implemented");
+	}
 
-    /**
-     * @return bool
-     */
-    public function SupportsStore() : bool
-    {
-        return false;
-    }
+	/**
+	 * @return bool
+	 */
+	public function SupportsStore(): bool
+	{
+		return false;
+	}
 
-    public function Name() : string { return "Test"; }
+	public function Name(): string
+	{
+		return "Test";
+	}
 }

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Suggestions/TestSuggestions.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/Suggestions/TestSuggestions.php
@@ -2,9 +2,11 @@
 
 namespace RainLoop\Providers\Suggestions;
 
-class TestSuggestions implements \RainLoop\Providers\Suggestions\ISuggestions
+use RainLoop\Model\Account;
+
+class TestSuggestions implements ISuggestions
 {
-	public function Process(\RainLoop\Model\Account $oAccount, string $sQuery, int $iLimit = 20) : array
+	public function Process(Account $oAccount, string $sQuery, int $iLimit = 20) : array
 	{
 		return array(
 			array($oAccount->Email(), ''),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3972,11 +3972,6 @@ istextorbinary@2.2.1:
     editions "^1.3.3"
     textextensions "2"
 
-jquery@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
Reworked the identity system to work with `Provider`s, just like the Suggestions system already has. This also includes plugin support, allowing plugins to set up the default identities for a user (e.g. based on LDAP data #40 ).

The basic idea is that there can be multiple `driver` registrations for the identities, that are layered on top of each other. Some are read-only, others are also writeable. The order of the drivers dictates their priority, newer ones override. Typically, you will only have 1 or 2 drivers. With only 1 driver (e.g. the file driver) the behaviour is identical to the current behaviour. The typical addition with a plugin would be to have a readonly provider (such as LDAP) as well, which provides a set of identities. When the user changes these, it is overridden and stored in the file provider. This allows the most flexibility.

Also added ldap to the php development container to allow developing the ldap contact suggestions plugin and potentially in the future #40 .