### PR TITLE
Added constructor to LDAP identities plugin

### DIFF
--- a/plugins/ldap-identities/index.php
+++ b/plugins/ldap-identities/index.php
@@ -11,6 +11,8 @@ class LdapIdentitiesPlugin extends AbstractPlugin
 		include_once __DIR__ . '/LdapIdentities.php';
 		include_once __DIR__ . '/LdapConfig.php';
 		include_once __DIR__ . '/LdapException.php';
+
+		parent::__construct();
 	}
 
 	public function Init(): void


### PR DESCRIPTION
Without the constructor, SnappyMail would crash when using custom language features. This is now resolved.