### PR TITLE
Improve ldap-contacts-suggestions plugin

### DIFF
--- a/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
+++ b/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
@@ -45,7 +45,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	/**
 	 * @var string
 	 */
-	private $sNameField = 'givenname';
+	private $sNameField = 'givenName';
 
 	/**
 	 * @var string
@@ -141,6 +141,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 		{
 			foreach ($aEmailFields as $sField)
 			{
+				$sField = \strtolower($sField);
 				if (!empty($aLdapItem[$sField][0]))
 				{
 					$sEmail = \trim($aLdapItem[$sField][0]);
@@ -153,6 +154,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 
 			foreach ($aNameFields as $sField)
 			{
+				$sField = \strtolower($sField);
 				if (!empty($aLdapItem[$sField][0]))
 				{
 					$sName = \trim($aLdapItem[$sField][0]);
@@ -165,6 +167,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 
 			foreach ($aUidFields as $sField)
 			{
+				$sField = \strtolower($sField);
 				if (!empty($aLdapItem[$sField][0]))
 				{
 					$sUid = \trim($aLdapItem[$sField][0]);

--- a/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
+++ b/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
@@ -5,7 +5,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	/**
 	 * @var string
 	 */
-	private $sLdapUri = 'ldap://127.0.0.1:389';
+	private $sLdapUri = 'ldap://localhost:389';
 
 	/**
 	 * @var bool

--- a/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
+++ b/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
@@ -25,7 +25,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	/**
 	 * @var string
 	 */
-	private $sBaseDn = '';
+	private $sBaseDn = 'ou=People,dc=example,dc=com';
 
 	/**
 	 * @var string
@@ -40,12 +40,12 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	/**
 	 * @var string
 	 */
-	private $sNameField = 'givenName';
+	private $sNameField = 'displayName,cn,givenName,sn';
 
 	/**
 	 * @var string
 	 */
-	private $sEmailField = 'mail';
+	private $sEmailField = 'mailAddress,mail,mailAlternateAddress,mailAlias';
 
 	/**
 	 * @var \MailSo\Log\Logger
@@ -55,7 +55,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	/**
 	 * @var string
 	 */
-	private $sAllowedEmails = '';
+	private $sAllowedEmails = '*';
 
 	/**
 	 * @param string $sLdapUri

--- a/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
+++ b/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
@@ -66,10 +66,11 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	 * @param string $sObjectClass
 	 * @param string $sNameField
 	 * @param string $sEmailField
+	 * @param string $sAllowedEmails
 	 *
 	 * @return \LdapContactsSuggestions
 	 */
-	public function SetConfig($sHostName, $iHostPort, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sUidField, $sNameField, $sEmailField)
+	public function SetConfig($sHostName, $iHostPort, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sUidField, $sNameField, $sEmailField, $sAllowedEmails)
 	{
 		$this->sHostName = $sHostName;
 		$this->iHostPort = $iHostPort;
@@ -83,17 +84,6 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 		$this->sUidField = $sUidField;
 		$this->sNameField = $sNameField;
 		$this->sEmailField = $sEmailField;
-
-		return $this;
-	}
-
-	/**
-	 * @param string $sAllowedEmails
-	 *
-	 * @return \LdapContactsSuggestions
-	 */
-	public function SetAllowedEmails($sAllowedEmails)
-	{
 		$this->sAllowedEmails = $sAllowedEmails;
 
 		return $this;

--- a/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
+++ b/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
@@ -13,6 +13,11 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	private $iHostPort = 389;
 
 	/**
+	 * @var bool
+	 */
+	private $bUseStartTLS = True;
+
+	/**
 	 * @var string
 	 */
 	private $sAccessDn = null;
@@ -60,6 +65,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	/**
 	 * @param string $sHostName
 	 * @param int $iHostPort
+	 * @param bool $bUseStartTLS
 	 * @param string $sAccessDn
 	 * @param string $sAccessPassword
 	 * @param string $sUsersDn
@@ -70,10 +76,11 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	 *
 	 * @return \LdapContactsSuggestions
 	 */
-	public function SetConfig($sHostName, $iHostPort, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sUidField, $sNameField, $sEmailField, $sAllowedEmails)
+	public function SetConfig($sHostName, $iHostPort, $bUseStartTLS, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sUidField, $sNameField, $sEmailField, $sAllowedEmails)
 	{
 		$this->sHostName = $sHostName;
 		$this->iHostPort = $iHostPort;
+		$this->bUseStartTLS = $bUseStartTLS;
 		if (0 < \strlen($sAccessDn))
 		{
 			$this->sAccessDn = $sAccessDn;
@@ -189,6 +196,12 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 			$this->oLogger->Write('ldap_connect: connected', \MailSo\Log\Enumerations\Type::INFO, 'LDAP');
 
 			@\ldap_set_option($oCon, LDAP_OPT_PROTOCOL_VERSION, 3);
+
+			if ($this->bUseStartTLS && !@\ldap_start_tls($oCon))
+			{
+				$this->logLdapError($oCon, 'ldap_start_tls');
+				return $aResult;
+			}
 
 			if (!@\ldap_bind($oCon, $this->sAccessDn, $this->sAccessPassword))
 			{

--- a/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
+++ b/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
@@ -5,12 +5,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	/**
 	 * @var string
 	 */
-	private $sHostName = '127.0.0.1';
-
-	/**
-	 * @var int
-	 */
-	private $iHostPort = 389;
+	private $sLdapUri = 'ldap://127.0.0.1:389';
 
 	/**
 	 * @var bool
@@ -63,8 +58,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	private $sAllowedEmails = '';
 
 	/**
-	 * @param string $sHostName
-	 * @param int $iHostPort
+	 * @param string $sLdapUri
 	 * @param bool $bUseStartTLS
 	 * @param string $sBindDn
 	 * @param string $sBindPassword
@@ -76,10 +70,9 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	 *
 	 * @return \LdapContactsSuggestions
 	 */
-	public function SetConfig($sHostName, $iHostPort, $bUseStartTLS, $sBindDn, $sBindPassword, $sBaseDn, $sObjectClass, $sUidField, $sNameField, $sEmailField, $sAllowedEmails)
+	public function SetConfig($sLdapUri, $bUseStartTLS, $sBindDn, $sBindPassword, $sBaseDn, $sObjectClass, $sUidField, $sNameField, $sEmailField, $sAllowedEmails)
 	{
-		$this->sHostName = $sHostName;
-		$this->iHostPort = $iHostPort;
+		$this->sLdapUri = $sLdapUri;
 		$this->bUseStartTLS = $bUseStartTLS;
 		if (0 < \strlen($sBindDn))
 		{
@@ -193,7 +186,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 		$sSearchEscaped = $this->escape($sQuery);
 
 		$aResult = array();
-		$oCon = @\ldap_connect($this->sHostName, $this->iHostPort);
+		$oCon = @\ldap_connect($this->sLdapUri);
 		if ($oCon)
 		{
 			$this->oLogger->Write('ldap_connect: connected', \MailSo\Log\Enumerations\Type::INFO, 'LDAP');

--- a/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
+++ b/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
@@ -35,17 +35,17 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	/**
 	 * @var string
 	 */
-	private $sUidField = 'uid';
+	private $sUidAttributes = 'uid';
 
 	/**
 	 * @var string
 	 */
-	private $sNameField = 'displayName,cn,givenName,sn';
+	private $sNameAttributes = 'displayName,cn,givenName,sn';
 
 	/**
 	 * @var string
 	 */
-	private $sEmailField = 'mailAddress,mail,mailAlternateAddress,mailAlias';
+	private $sEmailAttributes = 'mailAddress,mail,mailAlternateAddress,mailAlias';
 
 	/**
 	 * @var \MailSo\Log\Logger
@@ -64,13 +64,14 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	 * @param string $sBindPassword
 	 * @param string $sBaseDn
 	 * @param string $sObjectClass
-	 * @param string $sNameField
-	 * @param string $sEmailField
+	 * @param string $sNameAttributes
+	 * @param string $sEmailAttributes
+	 * @param string $sUidAttributes
 	 * @param string $sAllowedEmails
 	 *
 	 * @return \LdapContactsSuggestions
 	 */
-	public function SetConfig($sLdapUri, $bUseStartTLS, $sBindDn, $sBindPassword, $sBaseDn, $sObjectClass, $sUidField, $sNameField, $sEmailField, $sAllowedEmails)
+	public function SetConfig($sLdapUri, $bUseStartTLS, $sBindDn, $sBindPassword, $sBaseDn, $sObjectClass, $sUidAttributes, $sNameAttributes, $sEmailAttributes, $sAllowedEmails)
 	{
 		$this->sLdapUri = $sLdapUri;
 		$this->bUseStartTLS = $bUseStartTLS;
@@ -81,9 +82,9 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 		}
 		$this->sBaseDn = $sBaseDn;
 		$this->sObjectClass = $sObjectClass;
-		$this->sUidField = $sUidField;
-		$this->sNameField = $sNameField;
-		$this->sEmailField = $sEmailField;
+		$this->sUidAttributes = $sUidAttributes;
+		$this->sNameAttributes = $sNameAttributes;
+		$this->sEmailAttributes = $sEmailAttributes;
 		$this->sAllowedEmails = $sAllowedEmails;
 
 		return $this;
@@ -122,17 +123,18 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 
 	/**
 	 * @param array $aLdapItem
-	 * @param array $aEmailFields
-	 * @param array $aNameFields
+	 * @param array $aEmailAttributes
+	 * @param array $aNameAttributes
+	 * @param array $aUidAttributes
 	 *
 	 * @return array
 	 */
-	private function findNameAndEmail($aLdapItem, $aEmailFields, $aNameFields, $aUidFields)
+	private function findNameAndEmail($aLdapItem, $aEmailAttributes, $aNameAttributes, $aUidAttributes)
 	{
 		$sEmail = $sName = $sUid = '';
 		if ($aLdapItem)
 		{
-			foreach ($aEmailFields as $sField)
+			foreach ($aEmailAttributes as $sField)
 			{
 				$sField = \strtolower($sField);
 				if (!empty($aLdapItem[$sField][0]))
@@ -145,7 +147,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 				}
 			}
 
-			foreach ($aNameFields as $sField)
+			foreach ($aNameAttributes as $sField)
 			{
 				$sField = \strtolower($sField);
 				if (!empty($aLdapItem[$sField][0]))
@@ -158,7 +160,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 				}
 			}
 
-			foreach ($aUidFields as $sField)
+			foreach ($aUidAttributes as $sField)
 			{
 				$sField = \strtolower($sField);
 				if (!empty($aLdapItem[$sField][0]))
@@ -226,9 +228,9 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 				'{imap:port}' => $oAccount->DomainIncPort()
 			));
 
-			$aEmails = empty($this->sEmailField) ? array() : \explode(',', $this->sEmailField);
-			$aNames = empty($this->sNameField) ? array() : \explode(',', $this->sNameField);
-			$aUIDs = empty($this->sUidField) ? array() : \explode(',', $this->sUidField);
+			$aEmails = empty($this->sEmailAttributes) ? array() : \explode(',', $this->sEmailAttributes);
+			$aNames = empty($this->sNameAttributes) ? array() : \explode(',', $this->sNameAttributes);
+			$aUIDs = empty($this->sUidAttributes) ? array() : \explode(',', $this->sUidAttributes);
 
 			$aEmails = \array_map('trim', $aEmails);
 			$aNames = \array_map('trim', $aNames);

--- a/plugins/ldap-contacts-suggestions/index.php
+++ b/plugins/ldap-contacts-suggestions/index.php
@@ -86,7 +86,7 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 				->SetDefaultValue(''),
 			\RainLoop\Plugins\Property::NewInstance('base_dn')->SetLabel('Search base DN')
 				->SetDescription('DN to use as the search base. Supported tokens: {domain}, {domain:dc}, {email}, {email:user}, {email:domain}, {login}, {imap:login}, {imap:host}, {imap:port}')
-				->SetDefaultValue('ou=People,dc=domain,dc=com'),
+				->SetDefaultValue('ou=People,dc=example,dc=com'),
 			\RainLoop\Plugins\Property::NewInstance('object_class')->SetLabel('objectClass value')
 				->SetDefaultValue('inetOrgPerson'),
 			\RainLoop\Plugins\Property::NewInstance('uid_field')->SetLabel('uid attributes')
@@ -94,10 +94,10 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 				->SetDefaultValue('uid'),
 			\RainLoop\Plugins\Property::NewInstance('name_field')->SetLabel('Name attributes')
 				->SetDescription('LDAP attributes for user names, comma separated list in order of preference')
-				->SetDefaultValue('givenName'),
+				->SetDefaultValue('displayName,cn,givenName,sn'),
 			\RainLoop\Plugins\Property::NewInstance('mail_field')->SetLabel('Mail attributes')
 				->SetDescription('LDAP attributes for user email addresses, comma separated list in order of preference')
-				->SetDefaultValue('mail'),
+				->SetDefaultValue('mailAddress,mail,mailAlternateAddress,mailAlias'),
 			\RainLoop\Plugins\Property::NewInstance('allowed_emails')->SetLabel('Allowed emails')
 				->SetDescription('Email addresses of users which should be allowed to do LDAP lookups, space as delimiter, wildcard supported. Example: user1@domain1.net user2@domain1.net *@domain2.net')
 				->SetDefaultValue('*')

--- a/plugins/ldap-contacts-suggestions/index.php
+++ b/plugins/ldap-contacts-suggestions/index.php
@@ -4,9 +4,9 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 {
 	const
 		NAME = 'Contacts suggestions (LDAP)',
-		VERSION = '2.0',
+		VERSION = '2.1',
 		CATEGORY = 'Security',
-		DESCRIPTION = 'Plugin that adds functionality to get contacts from LDAP on compose page.';
+		DESCRIPTION = 'Plugin to get contacts suggestions from LDAP.';
 
 	public function Init() : void
 	{

--- a/plugins/ldap-contacts-suggestions/index.php
+++ b/plugins/ldap-contacts-suggestions/index.php
@@ -46,18 +46,18 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 				$sBindDn = \trim($this->Config()->Get('plugin', 'bind_dn', ''));
 				$sBindPassword = \trim($this->Config()->Get('plugin', 'bind_password', ''));
 				$sBaseDn = \trim($this->Config()->Get('plugin', 'base_dn', ''));
-				$sObjectClass = \trim($this->Config()->Get('plugin', 'object_class', ''));
+				$sObjectClasses = \trim($this->Config()->Get('plugin', 'object_classes', ''));
 				$sUidAttributes = \trim($this->Config()->Get('plugin', 'uid_attributes', ''));
 				$sNameAttributes = \trim($this->Config()->Get('plugin', 'name_attributes', ''));
 				$sEmailAttributes = \trim($this->Config()->Get('plugin', 'mail_attributes', ''));
 				$sAllowedEmails = \trim($this->Config()->Get('plugin', 'allowed_emails', ''));
 
-				if (0 < \strlen($sLdapUri) && 0 < \strlen($sBaseDn) && 0 < \strlen($sObjectClass) && 0 < \strlen($sEmailAttributes))
+				if (0 < \strlen($sLdapUri) && 0 < \strlen($sBaseDn) && 0 < \strlen($sObjectClasses) && 0 < \strlen($sEmailAttributes))
 				{
 					include_once __DIR__.'/LdapContactsSuggestions.php';
 
 					$oProvider = new LdapContactsSuggestions();
-					$oProvider->SetConfig($sLdapUri, $bUseStartTLS, $sBindDn, $sBindPassword, $sBaseDn, $sObjectClass, $sUidAttributes, $sNameAttributes, $sEmailAttributes, $sAllowedEmails);
+					$oProvider->SetConfig($sLdapUri, $bUseStartTLS, $sBindDn, $sBindPassword, $sBaseDn, $sObjectClasses, $sUidAttributes, $sNameAttributes, $sEmailAttributes, $sAllowedEmails);
 
 					$mResult[] = $oProvider;
 				}
@@ -87,7 +87,8 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 			\RainLoop\Plugins\Property::NewInstance('base_dn')->SetLabel('Search base DN')
 				->SetDescription('DN to use as the search base. Supported tokens: {domain}, {domain:dc}, {email}, {email:user}, {email:domain}, {login}, {imap:login}, {imap:host}, {imap:port}')
 				->SetDefaultValue('ou=People,dc=example,dc=com'),
-			\RainLoop\Plugins\Property::NewInstance('object_class')->SetLabel('objectClass value')
+			\RainLoop\Plugins\Property::NewInstance('object_classes')->SetLabel('objectClasses to use')
+				->SetDescription('LDAP objectClasses to search for, comma separated list')
 				->SetDefaultValue('inetOrgPerson'),
 			\RainLoop\Plugins\Property::NewInstance('uid_attributes')->SetLabel('uid attributes')
 				->SetDescription('LDAP attributes for userids, comma separated list in order of preference')

--- a/plugins/ldap-contacts-suggestions/index.php
+++ b/plugins/ldap-contacts-suggestions/index.php
@@ -74,7 +74,7 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 		return array(
 			\RainLoop\Plugins\Property::NewInstance('ldap_uri')->SetLabel('LDAP URI')
 				->SetDescription('LDAP server URI(s), space separated')
-				->SetDefaultValue('ldap://127.0.0.1:389'),
+				->SetDefaultValue('ldap://localhost:389'),
 			\RainLoop\Plugins\Property::NewInstance('use_start_tls')->SetLabel('Use StartTLS')
 				->SetType(\RainLoop\Enumerations\PluginPropertyType::BOOL)
 				->SetDefaultValue(True),

--- a/plugins/ldap-contacts-suggestions/index.php
+++ b/plugins/ldap-contacts-suggestions/index.php
@@ -43,6 +43,7 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 
 				$sHostName = \trim($this->Config()->Get('plugin', 'hostname', ''));
 				$iHostPort = (int) $this->Config()->Get('plugin', 'port', 389);
+				$bUseStartTLS = (bool) $this->Config()->Get('plugin', 'use_start_tls', True);
 				$sAccessDn = \trim($this->Config()->Get('plugin', 'access_dn', ''));
 				$sAccessPassword = \trim($this->Config()->Get('plugin', 'access_password', ''));
 				$sUsersDn = \trim($this->Config()->Get('plugin', 'users_dn_format', ''));
@@ -57,7 +58,7 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 					include_once __DIR__.'/LdapContactsSuggestions.php';
 
 					$oProvider = new LdapContactsSuggestions();
-					$oProvider->SetConfig($sHostName, $iHostPort, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sSearchField, $sNameField, $sEmailField, $sAllowedEmails);
+					$oProvider->SetConfig($sHostName, $iHostPort, $bUseStartTLS, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sSearchField, $sNameField, $sEmailField, $sAllowedEmails);
 
 					$mResult[] = $oProvider;
 				}
@@ -77,6 +78,9 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 			\RainLoop\Plugins\Property::NewInstance('port')->SetLabel('LDAP port')
 				->SetType(\RainLoop\Enumerations\PluginPropertyType::INT)
 				->SetDefaultValue(389),
+			\RainLoop\Plugins\Property::NewInstance('use_start_tls')->SetLabel('Use StartTLS')
+				->SetType(\RainLoop\Enumerations\PluginPropertyType::BOOL)
+				->SetDefaultValue(True),
 			\RainLoop\Plugins\Property::NewInstance('access_dn')->SetLabel('Access dn (login)')
 				->SetDescription('LDAP bind DN to authentifcate with. If left blank, anonymous bind will be tried and Access password will be ignored')
 				->SetDefaultValue(''),

--- a/plugins/ldap-contacts-suggestions/index.php
+++ b/plugins/ldap-contacts-suggestions/index.php
@@ -48,7 +48,7 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 				$sAccessPassword = \trim($this->Config()->Get('plugin', 'access_password', ''));
 				$sUsersDn = \trim($this->Config()->Get('plugin', 'users_dn_format', ''));
 				$sObjectClass = \trim($this->Config()->Get('plugin', 'object_class', ''));
-				$sSearchField = \trim($this->Config()->Get('plugin', 'search_field', ''));
+				$sUidField = \trim($this->Config()->Get('plugin', 'uid_field', ''));
 				$sNameField = \trim($this->Config()->Get('plugin', 'name_field', ''));
 				$sEmailField = \trim($this->Config()->Get('plugin', 'mail_field', ''));
 				$sAllowedEmails = \trim($this->Config()->Get('plugin', 'allowed_emails', ''));
@@ -58,7 +58,7 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 					include_once __DIR__.'/LdapContactsSuggestions.php';
 
 					$oProvider = new LdapContactsSuggestions();
-					$oProvider->SetConfig($sHostName, $iHostPort, $bUseStartTLS, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sSearchField, $sNameField, $sEmailField, $sAllowedEmails);
+					$oProvider->SetConfig($sHostName, $iHostPort, $bUseStartTLS, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sUidField, $sNameField, $sEmailField, $sAllowedEmails);
 
 					$mResult[] = $oProvider;
 				}
@@ -81,25 +81,28 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 			\RainLoop\Plugins\Property::NewInstance('use_start_tls')->SetLabel('Use StartTLS')
 				->SetType(\RainLoop\Enumerations\PluginPropertyType::BOOL)
 				->SetDefaultValue(True),
-			\RainLoop\Plugins\Property::NewInstance('access_dn')->SetLabel('Access dn (login)')
-				->SetDescription('LDAP bind DN to authentifcate with. If left blank, anonymous bind will be tried and Access password will be ignored')
+			\RainLoop\Plugins\Property::NewInstance('access_dn')->SetLabel('Bind DN')
+				->SetDescription('DN to bind (login) with. If left blank, anonymous bind will be tried and the password will be ignored')
 				->SetDefaultValue(''),
-			\RainLoop\Plugins\Property::NewInstance('access_password')->SetLabel('Access password')
+			\RainLoop\Plugins\Property::NewInstance('access_password')->SetLabel('Bind password')
 				->SetType(\RainLoop\Enumerations\PluginPropertyType::PASSWORD)
 				->SetDefaultValue(''),
-			\RainLoop\Plugins\Property::NewInstance('users_dn_format')->SetLabel('Users DN format')
-				->SetDescription('LDAP users dn format. Supported tokens: {email}, {login}, {domain}, {domain:dc}, {imap:login}, {imap:host}, {imap:port}')
+			\RainLoop\Plugins\Property::NewInstance('users_dn_format')->SetLabel('Search base DN')
+				->SetDescription('DN to use as the search base. Supported tokens: {domain}, {domain:dc}, {email}, {email:user}, {email:domain}, {login}, {imap:login}, {imap:host}, {imap:port}')
 				->SetDefaultValue('ou=People,dc=domain,dc=com'),
 			\RainLoop\Plugins\Property::NewInstance('object_class')->SetLabel('objectClass value')
 				->SetDefaultValue('inetOrgPerson'),
-			\RainLoop\Plugins\Property::NewInstance('search_field')->SetLabel('Search field')
+			\RainLoop\Plugins\Property::NewInstance('uid_field')->SetLabel('uid attributes')
+				->SetDescription('LDAP attributes for userids, comma separated list in order of preference')
 				->SetDefaultValue('uid'),
-			\RainLoop\Plugins\Property::NewInstance('name_field')->SetLabel('Name field')
+			\RainLoop\Plugins\Property::NewInstance('name_field')->SetLabel('Name attributes')
+				->SetDescription('LDAP attributes for user names, comma separated list in order of preference')
 				->SetDefaultValue('givenName'),
-			\RainLoop\Plugins\Property::NewInstance('mail_field')->SetLabel('Mail field')
+			\RainLoop\Plugins\Property::NewInstance('mail_field')->SetLabel('Mail attributes')
+				->SetDescription('LDAP attributes for user email addresses, comma separated list in order of preference')
 				->SetDefaultValue('mail'),
 			\RainLoop\Plugins\Property::NewInstance('allowed_emails')->SetLabel('Allowed emails')
-				->SetDescription('Allowed emails, space as delimiter, wildcard supported. Example: user1@domain1.net user2@domain1.net *@domain2.net')
+				->SetDescription('Email addresses of users which should be allowed to do LDAP lookups, space as delimiter, wildcard supported. Example: user1@domain1.net user2@domain1.net *@domain2.net')
 				->SetDefaultValue('*')
 		);
 	}

--- a/plugins/ldap-contacts-suggestions/index.php
+++ b/plugins/ldap-contacts-suggestions/index.php
@@ -50,13 +50,14 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 				$sSearchField = \trim($this->Config()->Get('plugin', 'search_field', ''));
 				$sNameField = \trim($this->Config()->Get('plugin', 'name_field', ''));
 				$sEmailField = \trim($this->Config()->Get('plugin', 'mail_field', ''));
+				$sAllowedEmails = \trim($this->Config()->Get('plugin', 'allowed_emails', ''));
 
 				if (0 < \strlen($sUsersDn) && 0 < \strlen($sObjectClass) && 0 < \strlen($sEmailField))
 				{
 					include_once __DIR__.'/LdapContactsSuggestions.php';
 
 					$oProvider = new LdapContactsSuggestions();
-					$oProvider->SetConfig($sHostName, $iHostPort, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sSearchField, $sNameField, $sEmailField);
+					$oProvider->SetConfig($sHostName, $iHostPort, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sSearchField, $sNameField, $sEmailField, $sAllowedEmails);
 
 					$mResult[] = $oProvider;
 				}

--- a/plugins/ldap-contacts-suggestions/index.php
+++ b/plugins/ldap-contacts-suggestions/index.php
@@ -41,8 +41,7 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 					$mResult = array();
 				}
 
-				$sHostName = \trim($this->Config()->Get('plugin', 'hostname', ''));
-				$iHostPort = (int) $this->Config()->Get('plugin', 'port', 389);
+				$sLdapUri = \trim($this->Config()->Get('plugin', 'ldap_uri', ''));
 				$bUseStartTLS = (bool) $this->Config()->Get('plugin', 'use_start_tls', True);
 				$sBindDn = \trim($this->Config()->Get('plugin', 'bind_dn', ''));
 				$sBindPassword = \trim($this->Config()->Get('plugin', 'bind_password', ''));
@@ -53,12 +52,12 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 				$sEmailField = \trim($this->Config()->Get('plugin', 'mail_field', ''));
 				$sAllowedEmails = \trim($this->Config()->Get('plugin', 'allowed_emails', ''));
 
-				if (0 < \strlen($sBaseDn) && 0 < \strlen($sObjectClass) && 0 < \strlen($sEmailField))
+				if (0 < \strlen($sLdapUri) && 0 < \strlen($sBaseDn) && 0 < \strlen($sObjectClass) && 0 < \strlen($sEmailField))
 				{
 					include_once __DIR__.'/LdapContactsSuggestions.php';
 
 					$oProvider = new LdapContactsSuggestions();
-					$oProvider->SetConfig($sHostName, $iHostPort, $bUseStartTLS, $sBindDn, $sBindPassword, $sBaseDn, $sObjectClass, $sUidField, $sNameField, $sEmailField, $sAllowedEmails);
+					$oProvider->SetConfig($sLdapUri, $bUseStartTLS, $sBindDn, $sBindPassword, $sBaseDn, $sObjectClass, $sUidField, $sNameField, $sEmailField, $sAllowedEmails);
 
 					$mResult[] = $oProvider;
 				}
@@ -73,11 +72,9 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 	protected function configMapping() : array
 	{
 		return array(
-			\RainLoop\Plugins\Property::NewInstance('hostname')->SetLabel('LDAP hostname')
-				->SetDefaultValue('127.0.0.1'),
-			\RainLoop\Plugins\Property::NewInstance('port')->SetLabel('LDAP port')
-				->SetType(\RainLoop\Enumerations\PluginPropertyType::INT)
-				->SetDefaultValue(389),
+			\RainLoop\Plugins\Property::NewInstance('ldap_uri')->SetLabel('LDAP URI')
+				->SetDescription('LDAP server URI(s), space separated')
+				->SetDefaultValue('ldap://127.0.0.1:389'),
 			\RainLoop\Plugins\Property::NewInstance('use_start_tls')->SetLabel('Use StartTLS')
 				->SetType(\RainLoop\Enumerations\PluginPropertyType::BOOL)
 				->SetDefaultValue(True),

--- a/plugins/ldap-contacts-suggestions/index.php
+++ b/plugins/ldap-contacts-suggestions/index.php
@@ -44,21 +44,21 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 				$sHostName = \trim($this->Config()->Get('plugin', 'hostname', ''));
 				$iHostPort = (int) $this->Config()->Get('plugin', 'port', 389);
 				$bUseStartTLS = (bool) $this->Config()->Get('plugin', 'use_start_tls', True);
-				$sAccessDn = \trim($this->Config()->Get('plugin', 'access_dn', ''));
-				$sAccessPassword = \trim($this->Config()->Get('plugin', 'access_password', ''));
-				$sUsersDn = \trim($this->Config()->Get('plugin', 'users_dn_format', ''));
+				$sBindDn = \trim($this->Config()->Get('plugin', 'bind_dn', ''));
+				$sBindPassword = \trim($this->Config()->Get('plugin', 'bind_password', ''));
+				$sBaseDn = \trim($this->Config()->Get('plugin', 'base_dn', ''));
 				$sObjectClass = \trim($this->Config()->Get('plugin', 'object_class', ''));
 				$sUidField = \trim($this->Config()->Get('plugin', 'uid_field', ''));
 				$sNameField = \trim($this->Config()->Get('plugin', 'name_field', ''));
 				$sEmailField = \trim($this->Config()->Get('plugin', 'mail_field', ''));
 				$sAllowedEmails = \trim($this->Config()->Get('plugin', 'allowed_emails', ''));
 
-				if (0 < \strlen($sUsersDn) && 0 < \strlen($sObjectClass) && 0 < \strlen($sEmailField))
+				if (0 < \strlen($sBaseDn) && 0 < \strlen($sObjectClass) && 0 < \strlen($sEmailField))
 				{
 					include_once __DIR__.'/LdapContactsSuggestions.php';
 
 					$oProvider = new LdapContactsSuggestions();
-					$oProvider->SetConfig($sHostName, $iHostPort, $bUseStartTLS, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sUidField, $sNameField, $sEmailField, $sAllowedEmails);
+					$oProvider->SetConfig($sHostName, $iHostPort, $bUseStartTLS, $sBindDn, $sBindPassword, $sBaseDn, $sObjectClass, $sUidField, $sNameField, $sEmailField, $sAllowedEmails);
 
 					$mResult[] = $oProvider;
 				}
@@ -81,13 +81,13 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 			\RainLoop\Plugins\Property::NewInstance('use_start_tls')->SetLabel('Use StartTLS')
 				->SetType(\RainLoop\Enumerations\PluginPropertyType::BOOL)
 				->SetDefaultValue(True),
-			\RainLoop\Plugins\Property::NewInstance('access_dn')->SetLabel('Bind DN')
+			\RainLoop\Plugins\Property::NewInstance('bind_dn')->SetLabel('Bind DN')
 				->SetDescription('DN to bind (login) with. If left blank, anonymous bind will be tried and the password will be ignored')
 				->SetDefaultValue(''),
-			\RainLoop\Plugins\Property::NewInstance('access_password')->SetLabel('Bind password')
+			\RainLoop\Plugins\Property::NewInstance('bind_password')->SetLabel('Bind password')
 				->SetType(\RainLoop\Enumerations\PluginPropertyType::PASSWORD)
 				->SetDefaultValue(''),
-			\RainLoop\Plugins\Property::NewInstance('users_dn_format')->SetLabel('Search base DN')
+			\RainLoop\Plugins\Property::NewInstance('base_dn')->SetLabel('Search base DN')
 				->SetDescription('DN to use as the search base. Supported tokens: {domain}, {domain:dc}, {email}, {email:user}, {email:domain}, {login}, {imap:login}, {imap:host}, {imap:port}')
 				->SetDefaultValue('ou=People,dc=domain,dc=com'),
 			\RainLoop\Plugins\Property::NewInstance('object_class')->SetLabel('objectClass value')

--- a/plugins/ldap-contacts-suggestions/index.php
+++ b/plugins/ldap-contacts-suggestions/index.php
@@ -95,7 +95,7 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 			\RainLoop\Plugins\Property::NewInstance('search_field')->SetLabel('Search field')
 				->SetDefaultValue('uid'),
 			\RainLoop\Plugins\Property::NewInstance('name_field')->SetLabel('Name field')
-				->SetDefaultValue('givenname'),
+				->SetDefaultValue('givenName'),
 			\RainLoop\Plugins\Property::NewInstance('mail_field')->SetLabel('Mail field')
 				->SetDefaultValue('mail'),
 			\RainLoop\Plugins\Property::NewInstance('allowed_emails')->SetLabel('Allowed emails')

--- a/plugins/ldap-contacts-suggestions/index.php
+++ b/plugins/ldap-contacts-suggestions/index.php
@@ -47,17 +47,17 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 				$sBindPassword = \trim($this->Config()->Get('plugin', 'bind_password', ''));
 				$sBaseDn = \trim($this->Config()->Get('plugin', 'base_dn', ''));
 				$sObjectClass = \trim($this->Config()->Get('plugin', 'object_class', ''));
-				$sUidField = \trim($this->Config()->Get('plugin', 'uid_field', ''));
-				$sNameField = \trim($this->Config()->Get('plugin', 'name_field', ''));
-				$sEmailField = \trim($this->Config()->Get('plugin', 'mail_field', ''));
+				$sUidAttributes = \trim($this->Config()->Get('plugin', 'uid_attributes', ''));
+				$sNameAttributes = \trim($this->Config()->Get('plugin', 'name_attributes', ''));
+				$sEmailAttributes = \trim($this->Config()->Get('plugin', 'mail_attributes', ''));
 				$sAllowedEmails = \trim($this->Config()->Get('plugin', 'allowed_emails', ''));
 
-				if (0 < \strlen($sLdapUri) && 0 < \strlen($sBaseDn) && 0 < \strlen($sObjectClass) && 0 < \strlen($sEmailField))
+				if (0 < \strlen($sLdapUri) && 0 < \strlen($sBaseDn) && 0 < \strlen($sObjectClass) && 0 < \strlen($sEmailAttributes))
 				{
 					include_once __DIR__.'/LdapContactsSuggestions.php';
 
 					$oProvider = new LdapContactsSuggestions();
-					$oProvider->SetConfig($sLdapUri, $bUseStartTLS, $sBindDn, $sBindPassword, $sBaseDn, $sObjectClass, $sUidField, $sNameField, $sEmailField, $sAllowedEmails);
+					$oProvider->SetConfig($sLdapUri, $bUseStartTLS, $sBindDn, $sBindPassword, $sBaseDn, $sObjectClass, $sUidAttributes, $sNameAttributes, $sEmailAttributes, $sAllowedEmails);
 
 					$mResult[] = $oProvider;
 				}
@@ -89,13 +89,13 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 				->SetDefaultValue('ou=People,dc=example,dc=com'),
 			\RainLoop\Plugins\Property::NewInstance('object_class')->SetLabel('objectClass value')
 				->SetDefaultValue('inetOrgPerson'),
-			\RainLoop\Plugins\Property::NewInstance('uid_field')->SetLabel('uid attributes')
+			\RainLoop\Plugins\Property::NewInstance('uid_attributes')->SetLabel('uid attributes')
 				->SetDescription('LDAP attributes for userids, comma separated list in order of preference')
 				->SetDefaultValue('uid'),
-			\RainLoop\Plugins\Property::NewInstance('name_field')->SetLabel('Name attributes')
+			\RainLoop\Plugins\Property::NewInstance('name_attributes')->SetLabel('Name attributes')
 				->SetDescription('LDAP attributes for user names, comma separated list in order of preference')
 				->SetDefaultValue('displayName,cn,givenName,sn'),
-			\RainLoop\Plugins\Property::NewInstance('mail_field')->SetLabel('Mail attributes')
+			\RainLoop\Plugins\Property::NewInstance('mail_attributes')->SetLabel('Mail attributes')
 				->SetDescription('LDAP attributes for user email addresses, comma separated list in order of preference')
 				->SetDefaultValue('mailAddress,mail,mailAlternateAddress,mailAlias'),
 			\RainLoop\Plugins\Property::NewInstance('allowed_emails')->SetLabel('Allowed emails')


### PR DESCRIPTION
The ldap-contacts-suggestions plugin has several issues: e.g. one option that isn't currently used (allowed emails), mishandling of attributes which aren't all lower-case, uses deprected ldap_connect functionality, doesn't support TLS and has a misleading and confusing documentation.

This patch series fixes all of the above. Tested in a VM using a LDAP server connection over SSL and TLS.