### PR TITLE
[snappymail] Allow deletion of parent folder with subfolders

### DIFF
--- a/dev/Model/FolderCollection.js
+++ b/dev/Model/FolderCollection.js
@@ -304,7 +304,7 @@ export class FolderModel extends AbstractModel {
 					return null;
 				},
 
-				canBeDeleted: () => !folder.isSystemFolder() && !folder.subFolders().length,
+				canBeDeleted: () => !folder.isSystemFolder() && folder.selectable,
 
 				canBeSubscribed: () => !folder.isSystemFolder()
 					&& SettingsUserStore.hideUnsubscribed()

--- a/dev/Settings/User/Folders.js
+++ b/dev/Settings/User/Folders.js
@@ -98,7 +98,7 @@ export class FoldersUserSettings {
 					if (folderToRemove === folder) {
 						return true;
 					}
-					folder.subFolders.remove(fRemoveFolder);
+					//folder.subFolders.remove(fRemoveFolder);
 					return false;
 				};
 


### PR DESCRIPTION
This change brings snappymails behaviour in line with RFC3501, section 6.3.4,
by allowing "real" (i.e. non-\Noselect) parent folders to be deleted and
by not performing a recursive deletion of subfolders.