### PR TITLE
fixed for php:7.4-fpm

### DIFF
--- a/.docker/dev/php/Dockerfile
+++ b/.docker/dev/php/Dockerfile
@@ -15,7 +15,7 @@ RUN pecl install xxtea-1.0.11 && \
 
 RUN docker-php-ext-configure intl && \
     docker-php-ext-configure ldap && \
-	docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
+	docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ && \
 	docker-php-ext-install opcache pdo_mysql zip intl gd ldap
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer


### PR DESCRIPTION
As per https://github.com/docker-library/php/issues/912

to correct build error: "configure: error: unrecognized options: --with-freetype-dir, --with-jpeg-dir"