### PR TITLE
change-password: Fix after password change

### DIFF
--- a/plugins/change-password/index.php
+++ b/plugins/change-password/index.php
@@ -176,7 +176,7 @@ class ChangePasswordPlugin extends \RainLoop\Plugins\AbstractPlugin
 		$oAccount->SetPassword($sNewPassword);
 		$oActions->SetAuthToken($oAccount);
 
-		return $this->jsonResponse(__FUNCTION__, $oActions->GetSpecAuthToken());
+		return $this->jsonResponse(__FUNCTION__, $oActions->AppData(false));
 	}
 
 	public static function encrypt(string $algo, string $password)

--- a/plugins/change-password/js/ChangePasswordUserSettings.js
+++ b/plugins/change-password/js/ChangePasswordUserSettings.js
@@ -117,7 +117,7 @@
 				this.newPassword('');
 				this.newPassword2('');
 				this.passwordUpdateSuccess(true);
-				rl.settings.set('AuthAccountHash', data.Result);
+				rl.setData(data.Result);
 			}
 		}
 	}


### PR DESCRIPTION
Use setData instead of deprecated methods after password change to refresh webapp.