### PR TITLE
change-password: Fix non-supported hash methods

### DIFF
--- a/plugins/change-password/index.php
+++ b/plugins/change-password/index.php
@@ -202,7 +202,7 @@ class ChangePasswordPlugin extends \RainLoop\Plugins\AbstractPlugin
 				break;
 		}
 
-		return $sPassword;
+		return $password;
 	}
 
 	private static function PasswordStrength(string $sPassword) : int


### PR DESCRIPTION
Fix encrypt when using non-supported hash method (by returning clear password, you shouldn't do that!)