### PR TITLE
Add Italian translation to TOTP

### DIFF
--- a/plugins/two-factor-auth/langs/it_IT.ini
+++ b/plugins/two-factor-auth/langs/it_IT.ini
@@ -1,0 +1,23 @@
+[POPUPS_TWO_FACTOR_TEST]
+TITLE_TEST_CODE = "Test di verifica a 2 fattori"
+LABEL_CODE = "Codice"
+[POPUPS_TWO_FACTOR_CFG]
+LEGEND_TWO_FACTOR_AUTH = "Verifica a 2 Fattori"
+LABEL_ENABLE_TWO_FACTOR = "Abilita la verifica a 2 fattori"
+LABEL_TWO_FACTOR_USER = "Utente"
+LABEL_TWO_FACTOR_STATUS = "Stato"
+LABEL_TWO_FACTOR_SECRET = "Chiave segreta"
+LABEL_TWO_FACTOR_BACKUP_CODES = "Codici di backup"
+BUTTON_CREATE = "Crea la chiave segreta"
+BUTTON_ACTIVATE = "Attiva"
+LINK_TEST = "test"
+BUTTON_SHOW_SECRET = "Mostra la chiave segreta"
+BUTTON_HIDE_SECRET = "Nascondi la chiave segreta"
+TWO_FACTOR_REQUIRE_DESC = "Il tuo account richiede la configurazione della verifica a 2 fattori."
+TWO_FACTOR_SECRET_CONFIGURED_DESC = "Configurato"
+TWO_FACTOR_SECRET_NOT_CONFIGURED_DESC = "Non configurato"
+TWO_FACTOR_SECRET_DESC = "Importa queste informazioni nella tua app Google Authenticator (o un altro programma per l'autenticazione a due fattori) utilizzando il codice QR fornito qui sotto o inserendo il codice manualmente.\n"
+TWO_FACTOR_BACKUP_CODES_DESC = "Se non riesci a ricevere i codici tramite Google Authenticator (o un altro programma per l'autenticazione a due fattori), puoi utilizzare i codici di backup per accedere. Dopo che hai utilizzato un codice di backup per accedere, diventerà inattivo.\n"
+TWO_FACTOR_SECRET_TEST_BEFORE_DESC = "Non puoi modificare questa impostazione prima del test."
+[LOGIN]
+LABEL_TWO_FACTOR_CODE = "Codice di Verifica"


### PR DESCRIPTION
Noticed it was missing.

Going to hijack this PR to also ask how `plugins/custom-admin-settings-tab/langs` and `plugins/custom-settings-tab/langs` work in terms of file formatting.

I noticed the only non-English files are named `ru.ini` instead of `ru_RU.ini`. If I were to add Italian and French files, would I need to name them `it.ini` or `fr_FR.ini`?