### PR TITLE
Update release dockerfile for PHP 7.4

### DIFF
--- a/.docker/release/Dockerfile
+++ b/.docker/release/Dockerfile
@@ -27,7 +27,7 @@ RUN mkdir -p /usr/share/man/man1/ /usr/share/man/man3/ /usr/share/man/man7/ && \
 RUN php -m && \
     docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && \
     docker-php-ext-configure intl && \
-    docker-php-ext-configure gd --with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include/ && \
+    docker-php-ext-configure gd --with-freetype --with-jpeg && \
     docker-php-ext-install ldap opcache pdo_mysql pdo_pgsql zip intl gd && \
     php -m
 


### PR DESCRIPTION
PHP 7.4 changed several extensions, including gd, to use pkg-config to find dependencies. These are the same changes as #191 but for the other Dockerfile.

I am currently successfully running the latest release via this Dockerfile, so it seems to work.