### PR TITLE
Remove duplicate HSTS header on Apache if mod_headers is loaded

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -23,7 +23,7 @@
 #	Header set Cache-Control "public, max-age=31536000"
 #	Header set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' data:; style-src 'self' 'unsafe-inline'"
 #	Header set Referrer-Policy "no-referrer"
-	Header set Strict-Transport-Security "max-age=31536000"
+#	Header set Strict-Transport-Security "max-age=31536000"
 	Header set imagetoolbar "no"
 #	Header set X-Content-Type-Options "nosniff"
 #	Header set X-Frame-Options "DENY"


### PR DESCRIPTION
On Apache httpd, `./.htaccess` sets HSTS if `mod_headers` is loaded, though `./v/0.0.0/include.php` does the same if envvar `HTTPS` is set, resulting in duplicate and thus invalid HSTS headers.
Beside confusing browsers, invalid HSTS also prevents `A+` rating in Qualys' SSLLabs HTTPS Server Check.
