### PR TITLE
Improve Japanese translation of "SEARCH".

### DIFF
--- a/snappymail/v/0.0.0/app/localization/ja-JP/user.json
+++ b/snappymail/v/0.0.0/app/localization/ja-JP/user.json
@@ -23,7 +23,7 @@
 		"PASSWORD": "パスワード",
 		"REPLY_TO": "Reply-To",
 		"SAVE": "保存",
-		"SEARCH": "連絡先が見つかりません",
+		"SEARCH": "検索",
 		"SPAM": "迷惑メール",
 		"SUBJECT": "件名",
 		"TEST": "テスト",


### PR DESCRIPTION
"Search" in English is "検索" in Japanese.