### PR TITLE
Change Ordering of SASLMechanisms

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/MailSo/Smtp/SmtpClient.php
+++ b/snappymail/v/0.0.0/app/libraries/MailSo/Smtp/SmtpClient.php
@@ -120,7 +120,7 @@ class SmtpClient extends \MailSo\Net\NetClient
 		$sPassword = $aCredentials['Password'];
 
 		$type = '';
-		$aCredentials['SASLMechanisms'][] = 'LOGIN';
+		array_unshift($aCredentials['SASLMechanisms'],'LOGIN');
 		foreach ($aCredentials['SASLMechanisms'] as $sasl_type) {
 			if ($this->IsAuthSupported($sasl_type) && \SnappyMail\SASL::isSupported($sasl_type)) {
 				$type = $sasl_type;


### PR DESCRIPTION
Want bw. Needed to change the ordering for SASL Mechanism...

Providers Mailserver seems to report PLAIN and LOGIN. But accepted no PLAIN:
so  code failed...

But think its better to ry LOGIN first neither
