### PR TITLE
2.20.5 - fix for broken admin login

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/RainLoop/ActionsAdmin.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/ActionsAdmin.php
@@ -123,7 +123,7 @@ class ActionsAdmin extends Actions
 			throw new ClientException(Notifications::AuthError);
 		}
 
-		$sToken = $this->setAdminAuthToken($sToken);
+		$sToken = $this->setAdminAuthToken();
 
 		return $this->DefaultResponse(__FUNCTION__, $sToken ? $this->AppData(true) : false);
 	}
@@ -667,7 +667,7 @@ class ActionsAdmin extends Actions
 		return $this->DefaultResponse(__FUNCTION__, $QR->__toString());
 	}
 
-	private function setAdminAuthToken(string $sToken) : string
+	private function setAdminAuthToken() : string
 	{
 		$sRand = \MailSo\Base\Utils::Sha1Rand();
 		if (!$this->Cacher(null, true)->Set(KeyPathHelper::SessionAdminKey($sRand), \time())) {


### PR DESCRIPTION
In 2.20.5 if you try to login to admin panel you get errors:

PHP message: PHP Notice: Undefined variable: sToken in /(...)/snappymail/v/2.20.5/app/libraries/RainLoop/ActionsAdmin.php on line 126

SERVICE[WARNING]: Argument 1 passed to RainLoop\ActionsAdmin::setAdminAuthToken() must be of the type string, null given, called in /(...)/snappymail/v/2.20.5/app/libraries/RainLoop/ActionsAdmin.php on line 126