### PR TITLE
Add information how the items in the plugin list have to be separated

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Config/Application.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Config/Application.php
@@ -252,7 +252,7 @@ Values:
 
 			'plugins' => array(
 				'enable'       => array(false, 'Enable plugin support'),
-				'enabled_list' => array('', 'List of enabled plugins'),
+				'enabled_list' => array('', 'Comma-separated list of enabled plugins'),
 			),
 
 			'defaults' => array(


### PR DESCRIPTION
As it happened to me that I wasn't sure how the list of activated plugins has to be formatted I would propose to modify the info text in the Admin Interface -> Config -> Plugins - enabled_list.

Hope this is the right file to modify - it worked on my system, but please check this 🙂.

Info: when you insert a ";" in the input field, the whole content of the field is deleted.