### PR TITLE
correcting name of exception class in plugin ldap-identities

### DIFF
--- a/plugins/ldap-identities/LdapException.php
+++ b/plugins/ldap-identities/LdapException.php
@@ -1,5 +1,5 @@
 <?php
 
-class LdapException extends \RainLoop\Exceptions\Exception
+class LdapException extends \RainLoop\Exceptions\ClientException
 {
 }

--- a/plugins/ldap-identities/LdapIdentities.php
+++ b/plugins/ldap-identities/LdapIdentities.php
@@ -129,11 +129,11 @@ class LdapIdentities implements IIdentities
 
 	/**
 	 * @inheritDoc
-	 * @throws \RainLoop\Exceptions\Exception
+	 * @throws \RainLoop\Exceptions\ClientException
 	 */
 	public function SetIdentities(Account $account, array $identities): void
 	{
-		throw new \RainLoop\Exceptions\Exception("Ldap identities provider does not support storage");
+		throw new \RainLoop\Exceptions\ClientException("Ldap identities provider does not support storage");
 	}
 
 	/**


### PR DESCRIPTION
The name was changed in SnappyMail and therefore blocking the activation of this plugin in the admin interface.