### PR TITLE
Plugin configuration did not load anymore when type was SELECTION

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Plugins/Property.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Plugins/Property.php
@@ -68,7 +68,7 @@ class Property implements \JsonSerializable
 				}
 				break;
 			case PluginPropertyType::SELECTION:
-				if ($this->aOptions && \in_array($mValue, $oItem->Options())) {
+				if ($this->aOptions && \in_array($mValue, $this->Options())) {
 					$this->mValue = (string) $mValue;
 				}
 				break;


### PR DESCRIPTION
Due to not existing object the plugin config dialog was not shown anymore.
I've substituted the non existing `$oItem` with `$this` and for me it worked afterwards.