### PR TITLE
Fix oauthbearer encoding

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/snappymail/sasl/oauth.php
+++ b/snappymail/v/0.0.0/app/libraries/snappymail/sasl/oauth.php
@@ -11,7 +11,7 @@ class OAuth extends \SnappyMail\SASL
 {
 	public function authenticate(string $username, string $passphrase, ?string $authzid = null) : string
 	{
-		return $this->encode("user={$username}\x01auth=Bearer {$passphrase}\x01\x01");
+		return $this->encode("n,a={$username},\x01auth=Bearer {$passphrase}\x01\x01");
 	}
 
 	public static function isSupported(string $param) : bool


### PR DESCRIPTION
- Fixes https://github.com/the-djmaze/snappymail/issues/758
- As per https://www.rfc-editor.org/rfc/rfc7628, we need to follow a format like:
```
n,a=user@example.com,^Ahost=server.example.com^Aport=143^A
   auth=Bearer vF9dft4qmTc2Nvb3RlckBhbHRhdmlzdGEuY29tCg==^A^A
```