### PR TITLE
Compact display of folders in nextcloud

### DIFF
--- a/integrations/nextcloud/snappymail/css/embed.css
+++ b/integrations/nextcloud/snappymail/css/embed.css
@@ -98,8 +98,8 @@ body > header ul {
 
 a.selectable {
 	margin: 2px;
-	height: 38px !important;
-	line-height: 38px !important;
+	height: 24px !important;
+	line-height: 24px !important;
 	border-radius: var(--border-radius-pill);
 }
 


### PR DESCRIPTION
With a long list of folders, there is too much space between folder names. This leads to the need to scroll unnecessarily.
With this pull request, the folder list is more compact which makes it clearly represented.