### PR TITLE
Added right margin to folder search input wrapper

### DIFF
--- a/dev/Styles/User/Layout.less
+++ b/dev/Styles/User/Layout.less
@@ -174,6 +174,10 @@ html.rl-side-preview-pane {
 	border-radius: var(--input-border-radius, 3px) !important;
 }
 
+.b-content .search-input-wrp {
+        margin-right: 8px;
+}
+
 .search-input-wrp {
 	position: relative;
 	text-align: right;


### PR DESCRIPTION
Fixed missing right margin at folder search input

Before:
![grafik](https://user-images.githubusercontent.com/43847817/214045405-e3368571-3fba-4641-b5ee-eb5af972c3ce.png)

After:
![grafik](https://user-images.githubusercontent.com/43847817/214045489-a0f01efc-e740-48aa-be58-2cd7e3c90ef2.png)

