### PR TITLE
Add Integrations with Apps to Documentation for Nextcloud

### DIFF
--- a/integrations/nextcloud/snappymail/README.md
+++ b/integrations/nextcloud/snappymail/README.md
@@ -32,6 +32,9 @@ From that point, all instance-wide SnappyMail settings can be tweaked as you wis
 
 ![grafik](https://user-images.githubusercontent.com/63400209/199768097-7bd939a7-56d0-47ba-b481-aeac08776fb4.png)
 
+## App Integrations
+### Contacts
+SnappyMail automatically connects with the Nextcloud contacts app. Download and install the [contacts app](https://apps.nextcloud.com/apps/contacts) for SnappyMail to obtain access to all registered users on the Nextcloud system, as well as users' personal contacts saved in here.
 
 ## SnappyMail Settings, Where Are They?
 


### PR DESCRIPTION
Just worked out all we needed to do to get all users to come through was enable the contacts app. Nice!!! would be good to have both mention and any specific details of [these features](https://apps.nextcloud.com/apps/snappymail) in the docs :) :
> Integration with other Nextcloud apps (Contacts, Files and Calendar)