### PR TITLE
Italian translation fix - password again

### DIFF
--- a/snappymail/v/0.0.0/app/localization/it-IT/admin.json
+++ b/snappymail/v/0.0.0/app/localization/it-IT/admin.json
@@ -6,7 +6,7 @@
 		"TEST": "Test",
 		"UPDATE": "Aggiorna",
 		"USERNAME": "Nome utente",
-		"PASSWORD": "Parola d'ordine",
+		"PASSWORD": "Password",
 		"CANCEL": "Annulla"
 	},
 	"LOGIN": {


### PR DESCRIPTION
sorry, PASSWORD lemma duplicate in admin.json too
for my opinion password is a common word that not require translation in italian