### PR TITLE
Use the System/Browser font by default

### DIFF
--- a/dev/Styles/@Boot.css
+++ b/dev/Styles/@Boot.css
@@ -1,7 +1,7 @@
 :root {
-	--fontSans: Verdana, Geneva, "Bitstream Vera Sans", "DejaVu LGC Sans", Arial, sans-serif;
-	--fontSerif: "Nimbus Roman No9 L", "Times New Roman", Times, FreeSerif, serif;
-	--fontMono: "Liberation Mono", Monaco, Menlo, Consolas, "Courier New", FreeMono, Courier, monospace;
+	--fontSans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+	--fontSerif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+	--fontMono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 #rl-app.fontArial {

--- a/snappymail/v/0.0.0/app/templates/Views/User/SettingsThemes.html
+++ b/snappymail/v/0.0.0/app/templates/Views/User/SettingsThemes.html
@@ -15,7 +15,7 @@
 	<div class="control-group">
 		<label>Sans-serif</label>
 		<select data-bind="value: fontSansSerif">
-			<option value=""></option>
+			<option value="">System Font</option>
 			<option value="Arial">Arial</option>
 			<option value="Lucida">Lucida</option>
 			<option value="Tahoma">Tahoma</option>
@@ -26,7 +26,7 @@
 	<div class="control-group">
 		<label>Serif</label>
 		<select data-bind="value: fontSerif">
-			<option value=""></option>
+			<option value="">System Font</option>
 			<option value="Times">Times</option>
 			<option value="Palatino">Palatino</option>
 			<option value="Georgia">Georgia</option>
@@ -35,7 +35,7 @@
 	<div class="control-group">
 		<label>Mono</label>
 		<select data-bind="value: fontMono">
-			<option value=""></option>
+			<option value="">System Font</option>
 			<option value="Courier">Courier</option>
 			<option value="Lucida">Lucida</option>
 		</select>


### PR DESCRIPTION
Currently, SnappyMail defaults to Verdana, which makes the actual "Verdana" setting irrelevant. Same goes for Serif and Monospace fonts.  
This PR makes the system-wide/browser-wide default fonts be used when the font is not configured in SnappyMail.

This will respect the user's browser settings, matching by default their Operating System's font.  
This PR also improves accessibility, as anyone who changed their browser font to something  more legible will actually see that change in SnappyMail.