### PR TITLE
Update German admin.json

### DIFF
--- a/snappymail/v/0.0.0/app/localization/de-DE/admin.json
+++ b/snappymail/v/0.0.0/app/localization/de-DE/admin.json
@@ -44,7 +44,7 @@
 		"LABEL_ALLOW_IDENTITIES": "Mehrere Identitäten erlauben",
 		"ALERT_DATA_ACCESS": "Auf den \"Data\"-Ordner kann zugegriffen werden. Konfiguriere den Ordner so, dass von extern nicht zugegriffen werden kann. Weitere Informationen:",
 		"ALERT_WARNING": "Warnung!",
-		"HTML_ALERT_WEAK_PASSWORD": "Sie verwenden das Standard-Admin-Passwort.\n<br>\nBitte <strong><a href=\"#\/security\">ändern<\/a><\/strong> Sie\n das Passwort aus Sicherheitsgründen!\n"
+		"HTML_ALERT_WEAK_PASSWORD": "Sie verwenden das Standard-Admin-Passwort.\n<br>\nBitte <strong><a href=\"#\/security\">ändern<\/a><\/strong> Sie\n das Passwort aus Sicherheitsgründen!"
 	},
 	"TAB_LOGIN": {
 		"LEGEND_LOGIN_SCREEN": "Anmeldebildschirm",
@@ -69,16 +69,16 @@
 		"LABEL_STORAGE_USER": "Benutzer",
 		"LABEL_STORAGE_PASSWORD": "Passwort",
 		"ALERT_NOTICE": "Hinweis!",
-		"SUGGESTIONS_LIMIT": "Suggestions limit",
+		"SUGGESTIONS_LIMIT": "Limit für Empfehlungen",
 		"HTML_ALERT_DO_NOT_USE_THIS_DATABASE": "Verwenden Sie diesen Datenbanktyp nicht bei einer hohen Anzahl aktiver Benutzer.",
-		"HTML_ALERT_DOES_NOT_SUPPORTED": "Ihr System unterstützt keine Kontakte.\n<br>\nSie müssen die <strong>PDO-Erweiterung (SQLite \/ MySQL \/ PostgreSQL)<\/strong> auf Ihrem Server installieren oder aktivieren.\n"
+		"HTML_ALERT_DOES_NOT_SUPPORTED": "Ihr System unterstützt keine Kontakte.\n<br>\nSie müssen die <strong>PDO-Erweiterung (SQLite \/ MySQL \/ PostgreSQL)<\/strong> auf Ihrem Server installieren oder aktivieren."
 	},
 	"TAB_DOMAINS": {
 		"LEGEND_DOMAINS": "Domains",
 		"BUTTON_ADD_DOMAIN": "Domain hinzufügen",
 		"BUTTON_ADD_ALIAS": "Alias hinzufügen",
 		"DELETE_ARE_YOU_SURE": "Sind Sie sicher?",
-		"HTML_DOMAINS_HELPER": "Liste der Domains, die Webmail abrufen darf.\n<br>\nKlicken Sie auf den Namen, um die Domain zu konfigurieren.\n"
+		"HTML_DOMAINS_HELPER": "Liste der Domains, die Webmail abrufen darf.\n<br>\nKlicken Sie auf den Namen, um die Domain zu konfigurieren."
 	},
 	"TAB_SECURITY": {
 		"LEGEND_SECURITY": "Sicherheit",
@@ -125,10 +125,10 @@
 		"LABEL_PORT": "Port",
 		"LABEL_SECURE": "Sicherheit",
 		"TIMEOUT": "Timeout",
-		"DISABLE_CAPABILITIES": "Disable capabilities",
-		"LIMITS": "Limits",
-		"FOLDERS": "Folders",
-		"MESSAGES": "Messages",
+		"DISABLE_CAPABILITIES": "Funktionen deaktivieren",
+		"LIMITS": "Grenzwerte",
+		"FOLDERS": "Ordner",
+		"MESSAGES": "Nachrichten",
 		"LABEL_WHITE_LIST": "Whitelist",
 		"SECURE_OPTION_NONE": "Ohne",
 		"LABEL_ALLOW_SIEVE_SCRIPTS": "Sieve-Skripte erlauben",
@@ -143,7 +143,7 @@
 		"BUTTON_BACK": "Zurück",
 		"BUTTON_UPDATE": "Aktualisieren",
 		"NEW_DOMAIN_DESC": "Diese Domain Konfiguration wird es dir möglich machen <br>mit <i>%NAME%<\/i> Mailadressen zu arbeiten.",
-		"WHITE_LIST_ALERT": "Liste der User, die Webmail abrufen darf.\nVerwenden Sie Leerzeichen als Trennsymbol.\n"
+		"WHITE_LIST_ALERT": "Liste der User, die Webmail abrufen darf.\nVerwenden Sie Leerzeichen als Trennsymbol."
 	},
 	"POPUPS_PLUGIN": {
 		"TITLE_PLUGIN": "Erweiterung",


### PR DESCRIPTION
Updated the german translation using https://snappymail.eu/translate.php?lang=de-DE .
@the-djmaze don't know if this is a bug of the translate.php or maybe this is wanted, but when you look into comparison of the files you see that the translate.php seams to strip trailing `\n` (example `HTML_ALERT_WEAK_PASSWORD`)