### PR TITLE
More default configs

### DIFF
--- a/dev/App/User.js
+++ b/dev/App/User.js
@@ -177,6 +177,7 @@ export class AppUser extends AbstractApp {
 	}
 
 	logout() {
+		localStorage.removeItem('register_protocol_offered');
 		Remote.request('Logout', () => rl.logoutReload(Settings.app('customLogoutLink')));
 	}
 
@@ -253,12 +254,15 @@ export class AppUser extends AbstractApp {
 
 						setTimeout(() => mailToHelper(SettingsGet('mailToEmail')), 500);
 
-						// When auto-login is active
-						navigator.registerProtocolHandler?.(
-							'mailto',
-							location.protocol + '//' + location.host + location.pathname + '?mailto&to=%s',
-							(SettingsGet('title') || 'SnappyMail')
-						);
+						if (!localStorage.getItem('register_protocol_offered')) {
+							// When auto-login is active
+							navigator.registerProtocolHandler?.(
+								'mailto',
+								location.protocol + '//' + location.host + location.pathname + '?mailto&to=%s',
+								(SettingsGet('title') || 'SnappyMail')
+							);
+							localStorage.setItem('register_protocol_offered', '1');
+						}
 
 					} else {
 						this.logout();

--- a/dev/App/User.js
+++ b/dev/App/User.js
@@ -247,7 +247,7 @@ export class AppUser extends AbstractApp {
 							}
 						}, 1);
 
-						setInterval(reloadTime(), 60000);
+						setInterval(reloadTime, 60000);
 
 						PgpUserStore.init();
 

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Actions.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Actions.php
@@ -680,7 +680,7 @@ class Actions
 					'contactsAllowed' => $this->AddressBookProvider($oAccount)->IsActive(),
 
 					'ViewHTML' => (bool) $oConfig->Get('defaults', 'view_html', true),
-					'ViewImages' => 'ask',
+					'ViewImages' => $oConfig->Get('defaults', 'view_images', 'ask'),
 					'ViewImagesWhitelist' => '',
 					'RemoveColors' => (bool) $oConfig->Get('defaults', 'remove_colors', false),
 					'AllowStyles' => false,
@@ -778,7 +778,7 @@ class Actions
 
 					$aResult['ViewHTML'] = (bool)$oSettings->GetConf('ViewHTML', $aResult['ViewHTML']);
 					$show_images = (bool) $oSettings->GetConf('ShowImages', false);
-					$aResult['ViewImages'] = $oSettings->GetConf('ViewImages', $show_images ? 'always' : 'ask');
+					$aResult['ViewImages'] = $oSettings->GetConf('ViewImages', $show_images ? 'always' : $aResult['ViewImages']);
 					$aResult['ViewImagesWhitelist'] = $oSettings->GetConf('ViewImagesWhitelist', '');
 					$aResult['RemoveColors'] = (bool)$oSettings->GetConf('RemoveColors', $aResult['RemoveColors']);
 					$aResult['AllowStyles'] = (bool)$oSettings->GetConf('AllowStyles', $aResult['AllowStyles']);

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Actions.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Actions.php
@@ -698,7 +698,7 @@ class Actions
 					'Layout' => (int) $oConfig->Get('defaults', 'view_layout', Enumerations\Layout::SIDE_PREVIEW),
 					'EditorDefaultType' => \str_replace('Forced', '', $oConfig->Get('defaults', 'view_editor_type', '')),
 					'UseCheckboxesInList' => (bool) $oConfig->Get('defaults', 'view_use_checkboxes', true),
-					'showNextMessage' => false,
+					'showNextMessage' => (bool) $oConfig->Get('defaults', 'view_show_next_message', false),
 					'AutoLogout' => (int) $oConfig->Get('defaults', 'autologout', 30),
 					'AllowDraftAutosave' => (bool) $oConfig->Get('defaults', 'allow_draft_autosave', true),
 					'ContactsAutosave' => (bool) $oConfig->Get('defaults', 'contacts_autosave', true),

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Actions.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Actions.php
@@ -691,7 +691,7 @@ class Actions
 					'listGrouped' => false,
 					'MessagesPerPage' => (int) $oConfig->Get('webmail', 'messages_per_page', 25),
 					'MessageReadDelay' => (int) $oConfig->Get('webmail', 'message_read_delay', 5),
-					'MsgDefaultAction' => 1,
+					'MsgDefaultAction' => (int) $oConfig->Get('defaults', 'msg_default_action', 1),
 					'SoundNotification' => true,
 					'NotificationSound' => 'new-mail',
 					'DesktopNotifications' => true,

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Config/Application.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Config/Application.php
@@ -298,7 +298,8 @@ Values:
 				'contacts_autosave'      => array(true),
 				'mail_use_threads'       => array(false),
 				'allow_draft_autosave'   => array(true),
-				'mail_reply_same_folder' => array(false)
+				'mail_reply_same_folder' => array(false),
+				'msg_default_action'     => array(1, '1 - reply, 2 - reply all'),
 			),
 
 			'logs' => array(

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Config/Application.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Config/Application.php
@@ -296,6 +296,10 @@ Values:
 				'autologout'             => array(30),
 				'view_html'              => array(true),
 				'show_images'            => array(false),
+				'view_images'            => array('ask', 'View external images:
+  "ask" - always ask
+  "match" - whitelist or ask
+  "always" - show always'),
 				'contacts_autosave'      => array(true),
 				'mail_use_threads'       => array(false),
 				'allow_draft_autosave'   => array(true),

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Config/Application.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Config/Application.php
@@ -292,6 +292,7 @@ Values:
 				'view_editor_type'       => array('Html', 'Editor mode used by default (Plain, Html)'),
 				'view_layout'            => array(1, 'layout: 0 - no preview, 1 - side preview, 2 - bottom preview'),
 				'view_use_checkboxes'    => array(true),
+				'view_show_next_message' => array(true, 'Show next message when (re)move current message'),
 				'autologout'             => array(30),
 				'view_html'              => array(true),
 				'show_images'            => array(false),


### PR DESCRIPTION
@the-djmaze Most of the requests for these changes are from users that are switching from other (web)mail clients. It would be nice to set `Defaults` for these instead of telling users what to change in their `Personal` settings. Thanks.

### Additional config defaults options
- "Replay All" as the default action (`msg_default_action`)
- Show next message after (re)move by default (`view_show_next_message`)
- Show image whitelisting (`view_images`)

### Firefox `add ProtocolHandler` pop-up
If the `add ProtocolHandler` pop-up is dismissed, Firefox (and maybe other non chrome) browsers show the pop again (and again) every time the page is reloaded. It would be less annoying if the popup is shown only once after (re)login.
  
![image](https://github.com/the-djmaze/snappymail/assets/10747559/52a42a95-b629-4b18-988c-47a8b0d10ad7)

This does not effect Chrome based browser because most of them show the little icon instead. 
![image](https://github.com/the-djmaze/snappymail/assets/10747559/2779d6f2-de31-45e5-a9e7-49379d3c9e7b)

