### PR TITLE
Sending group email to all contact addresses

### DIFF
--- a/dev/Model/Contact.js
+++ b/dev/Model/Contact.js
@@ -86,6 +86,7 @@ export class ContactModel extends AbstractModel {
 			focused: false,
 			selected: false,
 			checked: false,
+			sendToAll: true,
 
 			deleted: false,
 			readOnly: false,
@@ -139,7 +140,16 @@ export class ContactModel extends AbstractModel {
 	 */
 	getNameAndEmailHelper() {
 		let name = (this.givenName() + ' ' + this.surName()).trim(),
+			email;
+
+		if (this.sendToAll()) {
+			email = [];
+			this.email().forEach(function (key){
+				email.push(key?.value())
+			});
+		} else {
 			email = this.email()[0]?.value();
+		}
 /*
 //		this.jCard.getOne('fn')?.notEmpty() ||
 		this.jCard.parseFullName({set:true});
@@ -222,6 +232,9 @@ export class ContactModel extends AbstractModel {
 			value: ko.observable('')
 //			type: prop.params.type
 		});
+
+		if (this.sendToAllDisplayStatus())
+			document.getElementById('send-to-all').style.display = 'block';
 	}
 
 	addTel() {
@@ -318,4 +331,13 @@ export class ContactModel extends AbstractModel {
 			+ (this.checked() ? ' checked' : '')
 			+ (this.focused() ? ' focused' : '');
 	}
+
+	sendToAllDefaultValue() {
+		return (this.sendToAll() ? ' checked' : '');
+	}
+
+	sendToAllDisplayStatus() {
+		return this.email.length > 1
+	}
+
 }

--- a/dev/Styles/User/Contacts.less
+++ b/dev/Styles/User/Contacts.less
@@ -166,7 +166,7 @@
 			margin-bottom: 5px;
 		}
 
-		input[type='text'], textarea {
+		input:not([type='checkbox']), textarea {
 			width: 70vw;
 			max-width: 400px;
 		}

--- a/dev/Styles/User/Contacts.less
+++ b/dev/Styles/User/Contacts.less
@@ -166,9 +166,14 @@
 			margin-bottom: 5px;
 		}
 
-		input, textarea {
+		input[type='text'], textarea {
 			width: 70vw;
 			max-width: 400px;
+		}
+
+		#send-to-all > input[type="checkbox"] {
+			margin-left: 2px;
+			margin-right: 10px;
 		}
 	}
 

--- a/dev/View/Popup/Compose.js
+++ b/dev/View/Popup/Compose.js
@@ -1381,6 +1381,12 @@ export class ComposePopupView extends AbstractViewPopup {
 			}
 		});
 
+		let sToAddress = this.to();
+
+		if (/".*" <.*,.*>/g.test(sToAddress)) {
+			sToAddress = sToAddress.match(/<.*>/g)[0].replace(/[<>]/g, '');
+		}
+
 		const
 			identity = this.currentIdentity(),
 			params = {
@@ -1389,7 +1395,7 @@ export class ComposePopupView extends AbstractViewPopup {
 				messageUid: this.draftUid(),
 				saveFolder: sSaveFolder,
 				from: this.from(),
-				to: this.to(),
+				to: sToAddress,
 				cc: this.cc(),
 				bcc: this.bcc(),
 				replyTo: this.replyTo(),

--- a/snappymail/v/0.0.0/app/localization/en/user.json
+++ b/snappymail/v/0.0.0/app/localization/en/user.json
@@ -209,7 +209,8 @@
 		"ADD_MENU_BIRTHDAY": "Birthday",
 		"ADD_MENU_TAGS": "Tags",
 		"BUTTON_SHARE_ALL": "Everyone",
-		"BUTTON_SYNC": "Synchronization (CardDAV)"
+		"BUTTON_SYNC": "Synchronization (CardDAV)",
+		"SEND_TO_ALL_CONTACT_EMAILS": "Send to all contact emails"
 	},
 	"COMPOSE": {
 		"LINK_SHOW_INPUTS": "show all fields",

--- a/snappymail/v/0.0.0/app/templates/Views/User/PopupsContacts.html
+++ b/snappymail/v/0.0.0/app/templates/Views/User/PopupsContacts.html
@@ -134,6 +134,11 @@
 					<div class="control-group" data-bind="email().length">
 						<label class="fontastic iconsize24" data-i18n="[title]GLOBAL/EMAIL">@</label>
 						<div>
+							<div id="send-to-all" class="property-line"  data-bind="visible: sendToAllDisplayStatus()">
+								<input type="checkbox" data-bind="checked: sendToAll, css: sendToAllDefaultValue()">
+								<lable data-i18n="CONTACTS/SEND_TO_ALL_CONTACT_EMAILS"></lable>
+							</div>
+
 							<div data-bind="foreach: email">
 								<div class="property-line">
 									<span data-bind="text: value"></span>

--- a/snappymail/v/0.0.0/app/templates/Views/User/PopupsContacts.html
+++ b/snappymail/v/0.0.0/app/templates/Views/User/PopupsContacts.html
@@ -136,7 +136,7 @@
 						<div>
 							<div id="send-to-all" class="property-line"  data-bind="visible: sendToAllDisplayStatus()">
 								<input type="checkbox" data-bind="checked: sendToAll, css: sendToAllDefaultValue()">
-								<lable data-i18n="CONTACTS/SEND_TO_ALL_CONTACT_EMAILS"></lable>
+								<span data-i18n="CONTACTS/SEND_TO_ALL_CONTACT_EMAILS"></span>
 							</div>
 
 							<div data-bind="foreach: email">


### PR DESCRIPTION
Hello
I have implemented modifications to the Contacts section, enabling users to choose between sending an email to all addresses or only the first one.

So this feature provided sending email to group of users that it is very important for Organizations, and considering that most organizations require the ability to send group emails as discussed in issue #797 and #649, So it seems that better to been added this feature in general.

Also, this matter has been crucial for our migration plan to Snappymail, because previously I've been created this feature in Rainloop, which facilitated sending group emails.

Thanks.