### PR TITLE
Fix: '#/mailbox/folder/mUID/search' uri/route handling

### DIFF
--- a/dev/Common/UtilsUser.js
+++ b/dev/Common/UtilsUser.js
@@ -301,10 +301,14 @@ populateMessageBody = (oMessage, popup) => {
 				} else {
 					let json = oData?.Result;
 					if (json
-					 && oMessage.hash === json.hash
-//					 && oMessage.folder === json.folder
-//					 && oMessage.uid == json.uid
-					 && oMessage.revivePropertiesFromJson(json)
+						&& ((
+								oMessage.hash && oMessage.hash === json.hash
+							) || (
+								!oMessage.hash
+								&& oMessage.folder === json.folder
+								&& oMessage.uid == json.uid)
+						)
+						&& oMessage.revivePropertiesFromJson(json)
 					) {
 /*
 						if (bCached) {

--- a/integrations/nextcloud/snappymail/js/snappymail.js
+++ b/integrations/nextcloud/snappymail/js/snappymail.js
@@ -13,6 +13,7 @@ document.onreadystatechange = () => {
 		passThemesToIFrame();
 		let form = document.querySelector('form.snappymail');
 		form && SnappyMailFormHelper(form);
+		setupUnifiedSearchListener()
 	}
 };
 
@@ -136,15 +137,22 @@ function SnappyMailFormHelper(oForm)
 
 			return false;
 		});
-	}
-	catch(e) {
+	} catch (e) {
 		console.error(e);
 	}
 }
 
-addEventListener('hashchange', (event) => {
-	const search = event.newURL.substring(event.newURL.lastIndexOf('/') + 1);
-	if (search && search.length < 25) {
-		document.getElementById('rliframe').contentWindow.rl.app.messageList.mainSearch(search);
-	}
-});
+function setupUnifiedSearchListener() {
+	const iframe = document.getElementById('rliframe');
+	if (!iframe || !iframe.contentWindow) return;
+
+	addEventListener('hashchange', (event) => {
+		const hashIndex = event.newURL.indexOf('#/mailbox/');
+		if (hashIndex !== -1) {
+			const hash = event.newURL.substring(hashIndex + 1);
+			if (/\/[\w-]+\/[\w-]+\/\w\d+\/.{0,24}/.test(hash)) {
+				iframe.contentWindow.location.hash = hash;
+			}
+		}
+	});
+}


### PR DESCRIPTION
Routes like domain.tld/snappy/run/**#/mailbox/INBOX/m53/test** should show the `INBOX` folder with `test` in the search bar and the message with uid `53` selected. 
As per here:  https://github.com/the-djmaze/snappymail/blob/36789bd3b547a3078932a27142ec4b3e95ec7fa0/dev/Screen/User/MailBox.js#L131-L134

Therefore, `populateMessageBody()` function can be called with an empty `oMessage.hash` prop like here: https://github.com/the-djmaze/snappymail/blob/36789bd3b547a3078932a27142ec4b3e95ec7fa0/dev/Screen/User/MailBox.js#L76-L79

However, currently when the `oMessage.hash` prop is empty, the message is not displayed https://github.com/the-djmaze/snappymail/blob/36789bd3b547a3078932a27142ec4b3e95ec7fa0/dev/Common/UtilsUser.js#L303-L304 because the `json.hash` is always set to something.

---

The second commit improves NC iframe mode `hashchange` listener for unified search clicks 

_PS: sorry for re-lint on line 140_ 
