### PR TITLE
Fix threading view in Thunderbird (others?)

### DIFF
--- a/dev/View/Popup/Compose.js
+++ b/dev/View/Popup/Compose.js
@@ -864,7 +864,7 @@ export class ComposePopupView extends AbstractViewPopup {
 					this.prepareMessageAttachments(oLastMessage, options.mode);
 					this.aDraftInfo = ['reply', oLastMessage.uid, oLastMessage.folder];
 					this.sInReplyTo = oLastMessage.messageId;
-					this.sReferences = (oLastMessage.messageId + ' ' + oLastMessage.references).trim();
+					this.sReferences = (oLastMessage.references + ' ' + oLastMessage.messageId).trim();
 					// OpenPGP “Transferable Public Key”
 //					oLastMessage.autocrypt?.keydata
 					break;
@@ -875,7 +875,7 @@ export class ComposePopupView extends AbstractViewPopup {
 					this.prepareMessageAttachments(oLastMessage, options.mode);
 					this.aDraftInfo = ['forward', oLastMessage.uid, oLastMessage.folder];
 					this.sInReplyTo = oLastMessage.messageId;
-					this.sReferences = (oLastMessage.messageId + ' ' + oLastMessage.references).trim();
+					this.sReferences = (oLastMessage.references + ' ' + oLastMessage.messageId).trim();
 					break;
 
 				case ComposeType.Draft:

--- a/snappymail/v/0.0.0/app/libraries/MailSo/Mime/Header.php
+++ b/snappymail/v/0.0.0/app/libraries/MailSo/Mime/Header.php
@@ -156,8 +156,9 @@ class Header
 			}
 		}
 
-		// https://www.rfc-editor.org/rfc/rfc2822#section-2.1.1
-		return \wordwrap($this->NameWithDelimitrom() . $sResult, 78, "\r\n ");
+		// https://www.rfc-editor.org/rfc/rfc2822#section-2.1.1, avoid folding immediately after the header name
+                return $this->NameWithDelimitrom() . \wordwrap($sResult, 78 - \strlen($this->NameWithDelimitrom()) - 1, "\r\n ");
+
 	}
 
 	public function IsSubject() : bool


### PR DESCRIPTION
Replies sent via SnappyMail break thread view in Thunderbird due to not standard-compliant Reply-To and References headers.

- Due to the long IDs, the headers `Reply-To`, `References` (and `Messge-ID`) are split between the header name and its value. According to section RFC5322, section 2.2.3, this may be legal but it obviously causes problems.

- On subsequent replies, the parent's ID gets prepended to the `References` header. Section 3.6.4 of the same RFC specifies that the ID should be appended to that header.