### PR TITLE
Fix: listen on IPv6 socket as well in container

### DIFF
--- a/.docker/release/files/etc/nginx/nginx.conf
+++ b/.docker/release/files/etc/nginx/nginx.conf
@@ -52,6 +52,7 @@ http {
 
   server {
     listen 8888;
+    listen [::]:8888;
     root /snappymail;
     index index.php;
     charset utf-8;


### PR DESCRIPTION
Snappymail can't be deployed in k8s. Healtheck hangs:
https://github.com/the-djmaze/snappymail/blob/79348f975f69951c64b794c0b9c76902d0e02aab/.docker/release/files/entrypoint.sh#L65
In _some_ k8s environments `localhost` resolves to IPv6:
```
snappymail-0:/snappymail# nc -vvvv localhost 8888
nc: localhost ([::1]:8888): Connection refused
sent 0, rcvd 0
```

But nginx isn't aware of it:

https://github.com/the-djmaze/snappymail/blob/79348f975f69951c64b794c0b9c76902d0e02aab/.docker/release/files/etc/nginx/nginx.conf#L53-L55
---
This PR fixes that.