### PR TITLE
Enhancement (docker): Build but don't push on `master`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,10 @@ name: docker
 
 on:
   push:
+    branches:
+    - master
     tags:
-    - '**'
+    - 'v2.*'
   pull_request:
     branches:
     - master


### PR DESCRIPTION
Run builds on master so we know if changes on master breaks builds.

Reverts `on: tags` to match `v2.*` which was changed in #1325