### PR TITLE
Enhancement (ci): Use separate workflow for PR docker builds

### DIFF
--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -1,14 +1,9 @@
-name: docker
+name: docker-pr
 
 on:
-  push:
-    tags:
-    - 'v2.*'
-
-# This is needed to push to GitHub Container Registry. See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
-permissions:
-  contents: read
-  packages: write
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:
@@ -28,11 +23,10 @@ jobs:
         images: |
           djmaze/snappymail
           ghcr.io/${{ github.repository }}
-        # type=ref,event=branch generates tag(s) on branch only. E.g. 'master', 'master-abc0123'
-        # type=ref,event=tag generates tag(s) on tags only. E.g. 'v0.0.0', 'v0.0.0-abc0123', and 'latest'
+        # type=ref,event=pr generates tag(s) on PRs only. E.g. 'pr-123', 'pr-123-abc0123'
         tags: |
-          type=ref,event=branch
-          type=ref,event=tag
+          type=ref,event=pr
+          type=ref,suffix=-{{sha}},event=pr
         # The rest of the org.opencontainers.image.xxx labels are dynamically generated
         labels: |
           org.opencontainers.image.description=SnappyMail
@@ -53,21 +47,6 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
-
-    - name: Login to Docker Hub registry
-      if: startsWith(github.ref, 'refs/tags/')  # Login only on tags
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Login to GitHub Container Registry
-      if: startsWith(github.ref, 'refs/tags/')  # Login only on tags
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
 
     # See: https://github.com/docker/buildx/issues/59
     - name: Build
@@ -93,16 +72,13 @@ jobs:
         TAG=$( echo "${{ steps.meta.outputs.tags }}" | head -n1 )
         .docker/release/test/test.sh "$TAG"
 
-    - name: Build and push
-      id: build-and-push
+    - name: Build all archs
       uses: docker/build-push-action@v3
       with:
         context: '.'
         file: ./.docker/release/Dockerfile
-        # TODO: Add more arches?
-        # platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         platforms: linux/386,linux/amd64,linux/arm64
-        push: ${{ startsWith(github.ref, 'refs/tags/') }}  # Push only on tags
+        push: false
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=local,src=/tmp/.buildx-cache

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <h1>SnappyMail</h1>
   <br>
 
-[![github-actions](https://github.com/the-djmaze/snappymail/workflows/docker/badge.svg)](https://github.com/the-djmaze/snappymail/actions/workflows/docker.yml)
+[![github-actions](https://github.com/the-djmaze/snappymail/actions/workflows/docker.yml/badge.svg)](https://github.com/the-djmaze/snappymail/actions/workflows/docker.yml)
 [![docker-image-size](https://img.shields.io/docker/image-size/djmaze/snappymail/latest)](https://hub.docker.com/r/djmaze/snappymail/tags)
 
   <p>


### PR DESCRIPTION
This is so the `docker` workflow status is not polluted with PR builds.