### PR TITLE
Mark Account password as sensitive information

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Model/Account.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Model/Account.php
@@ -14,6 +14,7 @@ abstract class Account implements \JsonSerializable
 
 	private string $sLogin = '';
 
+	 #[\SensitiveParameter]
 	private string $sPassword = '';
 
 	private string $sSmtpLogin = '';


### PR DESCRIPTION
Mark Account password as sensitive information, so it won't get included in log files.

I discovered the password is logged in clear text, i.e. in the trace I reported to php-src here: https://github.com/php/php-src/issues/12860

This is to avoid logging of the password value in stack traces.

see https://www.php.net/manual/en/class.sensitiveparameter.php