### PR TITLE
fix: flag indicators are added to wrong message when another message is selected while composing

### DIFF
--- a/dev/View/Popup/Compose.js
+++ b/dev/View/Popup/Compose.js
@@ -500,10 +500,10 @@ export class ComposePopupView extends AbstractViewPopup {
 										'forward': '$forwarded'
 									}[this.aDraftInfo[0]];
 									if (flag) {
-										const aFlags = MessageUserStore.message().flags();
+										const aFlags = oLastMessage.flags();
 										if (aFlags.indexOf(flag) === -1) {
 											aFlags.push(flag);
-											MessageUserStore.message().flags(aFlags);
+											oLastMessage.flags(aFlags);
 										}
 									}
 								}


### PR DESCRIPTION
The bug happens when current composer window is minimized and an other message is selected for viewing and then composer is resorted and the message in the composer is forwarded or replied. 