### PR TITLE
make nextcloud language work with snappy

### DIFF
--- a/plugins/nextcloud/index.php
+++ b/plugins/nextcloud/index.php
@@ -254,8 +254,8 @@ class NextcloudPlugin extends \RainLoop\Plugins\AbstractPlugin
 			}
 			$user = \OC::$server->getUserSession()->getUser();
 			$userId = $user->getUID();
-			$userLang = \OC::$server->getConfig()->getUserValue($userId, 'core', 'lang');
-			$sLanguage = $this->determineLocale($langCode,$aResultLang['LANGS_NAMES_EN']);
+			$userLang = \OC::$server->getConfig()->getUserValue($userId, 'core', 'lang','en');
+			$sLanguage = $this->determineLocale($userLang,$aResultLang['LANGS_NAMES_EN']);
 			// Check if $sLanguage is null
 			if ($sLanguage === null) {
 				$sLanguage = 'en'; // Assign 'en' if $sLanguage is null

--- a/plugins/nextcloud/index.php
+++ b/plugins/nextcloud/index.php
@@ -248,14 +248,11 @@ class NextcloudPlugin extends \RainLoop\Plugins\AbstractPlugin
 	public function FilterLanguage(&$sLanguage, $bAdmin) : void
 	{
 		if (!\RainLoop\Api::Config()->Get('webmail', 'allow_languages_on_settings', true)) {
-			$aResultLang = \json_decode(\file_get_contents(APP_VERSION_ROOT_PATH . 'app/localization/langs.json'), true);
-			if ($aResultLang === null) {
-				throw new \Exception('Error decoding JSON content.');
-			}
+			$aResultLang = \SnappyMail\L10n::getLanguages(false);
 			$user = \OC::$server->getUserSession()->getUser();
 			$userId = $user->getUID();
 			$userLang = \OC::$server->getConfig()->getUserValue($userId, 'core', 'lang','en');
-			$sLanguage = $this->determineLocale($userLang,$aResultLang['LANGS_NAMES_EN']);
+			$sLanguage = $this->determineLocale($userLang,$aResultLang);
 			// Check if $sLanguage is null
 			if ($sLanguage === null) {
 				$sLanguage = 'en'; // Assign 'en' if $sLanguage is null
@@ -273,20 +270,20 @@ class NextcloudPlugin extends \RainLoop\Plugins\AbstractPlugin
 	 */
 	private function determineLocale (string $langCode, array $languagesArray) : string {
 		// Direct check for the language code
-		if (isset($languagesArray[$langCode])) {
+		if (in_array($langCode, $languagesArray)) {	
 			return $langCode;
 		}
 	
 		// Check with uppercase country code
 		$langCodeWithUpperCase = $langCode . '-' . strtoupper($langCode);
-		if (isset($languagesArray[$langCodeWithUpperCase])) {
+		if (in_array($langCodeWithUpperCase, $languagesArray)) {		
 			return $langCodeWithUpperCase;
 		}
 	
 		// Iterating to find a match starting with langCode
-		foreach ($languagesArray as $localeKey => $localeValue) {
-			if (strpos($localeKey, $langCode) === 0) {
-				return $localeKey;
+		foreach ($languagesArray as $localeValue) {
+			if (strpos($localeValue, $langCode) === 0) {
+				return $localeValue;
 			}
 		}
 

--- a/snappymail/v/0.0.0/app/libraries/snappymail/l10n.php
+++ b/snappymail/v/0.0.0/app/libraries/snappymail/l10n.php
@@ -8,7 +8,7 @@ abstract class L10n
 	/**
 	 * @staticvar array $aCache
 	 */
-	public static function (bool $bAdmin = false) : array
+	public static function getLanguages(bool $bAdmin = false) : array
 	{
 		static $aCache = array();
 

--- a/snappymail/v/0.0.0/app/libraries/snappymail/l10n.php
+++ b/snappymail/v/0.0.0/app/libraries/snappymail/l10n.php
@@ -8,7 +8,7 @@ abstract class L10n
 	/**
 	 * @staticvar array $aCache
 	 */
-	public static function getLanguages(bool $bAdmin = false) : array
+	public static function (bool $bAdmin = false) : array
 	{
 		static $aCache = array();
 


### PR DESCRIPTION
In this PR-
I tried to resolve nextcloud language to work with snappy by handling following cases:

1. If user nextcloud language matches snappy locale then snappy locale will be loaded
2. If user language is $lang Check if $lang-$LANG matches snappy locale then $lang-$LANG locale will be loaded
3. match first match in snappy locales that starts with user lang $lang and load that first matched locale
4. if any of the above case is not match load locale en.