### PR TITLE
StartTLS for LDAP Identities plugin

### DIFF
--- a/plugins/ldap-identities/LdapConfig.php
+++ b/plugins/ldap-identities/LdapConfig.php
@@ -7,6 +7,7 @@ class LdapConfig
 {
 	public const CONFIG_SERVER = "server";
 	public const CONFIG_PROTOCOL_VERSION = "server_version";
+	public const CONFIG_STARTTLS = "starttls";
 
 	public const CONFIG_BIND_USER = "bind_user";
 	public const CONFIG_BIND_PASSWORD = "bind_password";
@@ -28,6 +29,7 @@ class LdapConfig
 
 	public $server;
 	public $protocol;
+	public $starttls;
 	public $bind_user;
 	public $bind_password;
 	public $user_base;
@@ -48,6 +50,7 @@ class LdapConfig
 		$ldap = new self();
 		$ldap->server = trim($config->Get("plugin", self::CONFIG_SERVER));
 		$ldap->protocol = (int)trim($config->Get("plugin", self::CONFIG_PROTOCOL_VERSION, 3));
+		$ldap->starttls = (bool)trim($config->Get("plugin", self::CONFIG_STARTTLS));
 		$ldap->bind_user = trim($config->Get("plugin", self::CONFIG_BIND_USER));
 		$ldap->bind_password = trim($config->Get("plugin", self::CONFIG_BIND_PASSWORD));
 		$ldap->user_base = trim($config->Get("plugin", self::CONFIG_USER_BASE));

--- a/plugins/ldap-identities/LdapIdentities.php
+++ b/plugins/ldap-identities/LdapIdentities.php
@@ -178,6 +178,15 @@ class LdapIdentities implements IIdentities
 			return false;
 		}
 
+		// Activate StartTLS
+		if ($this->config->starttls) {
+			$starttlsResult = ldap_start_tls($ldap);
+			if (!$starttlsResult) {
+				$this->ldapAvailable = false;
+				return false;
+			}
+		}
+		
 		$this->ldap = $ldap;
 		$this->ldapConnected = true;
 		return true;

--- a/plugins/ldap-identities/index.php
+++ b/plugins/ldap-identities/index.php
@@ -57,6 +57,12 @@ class LdapIdentitiesPlugin extends AbstractPlugin
 				->SetLabel("LDAP Protocol Version")
 				->SetType(PluginPropertyType::SELECTION)
 				->SetDefaultValue([2, 3]),
+				
+			Property::NewInstance(LdapConfig::CONFIG_STARTTLS)
+				->SetLabel("Use StartTLS")
+				->SetType(PluginPropertyType::BOOL)
+				->SetDescription("Whether or not to use TLS encrypted connection")
+				->SetDefaultValue(true),
 
 			Property::NewInstance(LdapConfig::CONFIG_BIND_USER)
 				->SetLabel("Bind User DN")

--- a/plugins/ldap-identities/index.php
+++ b/plugins/ldap-identities/index.php
@@ -8,10 +8,10 @@ class LdapIdentitiesPlugin extends AbstractPlugin
 {
 	const
 		NAME     = 'LDAP Identities',
-		VERSION  = '2.1',
+		VERSION  = '2.2',
 		AUTHOR   = 'FWest98',
 		URL      = 'https://github.com/FWest98',
-		RELEASE  = '2022-11-09',
+		RELEASE  = '2024-02-22',
 		REQUIRED = '2.20.0',
 		CATEGORY = 'Accounts',
 		DESCRIPTION = 'Adds functionality to import account identities from LDAP.';


### PR DESCRIPTION
The LDAP Identities plugin missed a way to connect to servers which demand a secure TLS connection via StartTLS.
Therefore I've added an option in the config to activate StartTLS and changed the Connect function in LdapIdentities.php to use StartTLS if it's activated.