### PR TITLE
Added function for ldap-identities plugin to filter by mail prefixes (allow compatibility for e.g. Exchange and others)

### DIFF
--- a/plugins/ldap-identities/LdapConfig.php
+++ b/plugins/ldap-identities/LdapConfig.php
@@ -8,6 +8,7 @@ class LdapConfig
 	public const CONFIG_SERVER = "server";
 	public const CONFIG_PROTOCOL_VERSION = "server_version";
 	public const CONFIG_STARTTLS = "starttls";
+	public const CONFIG_MAIL_PREFIX = "mail_prefix";
 
 	public const CONFIG_BIND_USER = "bind_user";
 	public const CONFIG_BIND_PASSWORD = "bind_password";
@@ -30,6 +31,7 @@ class LdapConfig
 	public $server;
 	public $protocol;
 	public $starttls;
+	public $mail_prefix;
 	public $bind_user;
 	public $bind_password;
 	public $user_base;
@@ -51,6 +53,7 @@ class LdapConfig
 		$ldap->server = trim($config->Get("plugin", self::CONFIG_SERVER));
 		$ldap->protocol = (int)trim($config->Get("plugin", self::CONFIG_PROTOCOL_VERSION, 3));
 		$ldap->starttls = (bool)trim($config->Get("plugin", self::CONFIG_STARTTLS));
+		$ldap->mail_prefix = trim($config->Get("plugin", self::CONFIG_MAIL_PREFIX));
 		$ldap->bind_user = trim($config->Get("plugin", self::CONFIG_BIND_USER));
 		$ldap->bind_password = trim($config->Get("plugin", self::CONFIG_BIND_PASSWORD));
 		$ldap->user_base = trim($config->Get("plugin", self::CONFIG_USER_BASE));

--- a/plugins/ldap-identities/LdapIdentities.php
+++ b/plugins/ldap-identities/LdapIdentities.php
@@ -289,12 +289,14 @@ class LdapIdentities implements IIdentities
 		@paraam string $mailPrefix
 		@return array
 		*/
-		private function CleanupMailAddresses(array $entries, string $mailField, string $mailPrefix) {
+		private function CleanupMailAddresses(array $entries, string $mailField, string $mailPrefix)
+		{
 			if (!empty($mailPrefix)) {
 				for ($i = 0; $i < $entries["count"]; $i++) {
 					// Remove addresses without the given prefix
 					$entries[$i]["$mailField"] = array_filter($entries[$i]["$mailField"],
-													function($prefixMail) {
+													function($prefixMail)
+													{
 														// $mailPrefix can't be used here, because it's nailed to the CleanupMailAddresses function and can't be passed to the array_filter function afaik.
 														// Ideas to avoid this are welcome.
 														if (stripos($prefixMail, $this->config->mail_prefix) === 0) {
@@ -320,7 +322,6 @@ class LdapIdentities implements IIdentities
 
 			return $entries;
 		}
-
 
 	/**
 	 * @param array $entry

--- a/plugins/ldap-identities/LdapIdentities.php
+++ b/plugins/ldap-identities/LdapIdentities.php
@@ -280,48 +280,48 @@ class LdapIdentities implements IIdentities
 		return $results;
 	}
 
-		// Function CleanupMailAddresses(): If a prefix is given this function removes addresses without / with the wrong prefix and then the prefix itself from all remaining values.
-		// This is usefull for example for importing Active Directory LDAP entry "proxyAddresses" which can hold different address types with prefixes like "X400:", "smtp:" "sip:" and others.
+	// Function CleanupMailAddresses(): If a prefix is given this function removes addresses without / with the wrong prefix and then the prefix itself from all remaining values.
+	// This is usefull for example for importing Active Directory LDAP entry "proxyAddresses" which can hold different address types with prefixes like "X400:", "smtp:" "sip:" and others.
 
-		/**
-		@param array $entries
-		@param string $mailField
-		@paraam string $mailPrefix
-		@return array
-		*/
-		private function CleanupMailAddresses(array $entries, string $mailField, string $mailPrefix)
-		{
-			if (!empty($mailPrefix)) {
-				for ($i = 0; $i < $entries["count"]; $i++) {
-					// Remove addresses without the given prefix
-					$entries[$i]["$mailField"] = array_filter($entries[$i]["$mailField"],
-													function($prefixMail)
-													{
-														// $mailPrefix can't be used here, because it's nailed to the CleanupMailAddresses function and can't be passed to the array_filter function afaik.
-														// Ideas to avoid this are welcome.
-														if (stripos($prefixMail, $this->config->mail_prefix) === 0) {
-															return TRUE;
-														}
-														return FALSE;
+	/**
+	@param array $entries
+	@param string $mailField
+	@paraam string $mailPrefix
+	@return array
+	*/
+	private function CleanupMailAddresses(array $entries, string $mailField, string $mailPrefix)
+	{
+		if (!empty($mailPrefix)) {
+			for ($i = 0; $i < $entries["count"]; $i++) {
+				// Remove addresses without the given prefix
+				$entries[$i]["$mailField"] = array_filter($entries[$i]["$mailField"],
+												function($prefixMail)
+												{
+													// $mailPrefix can't be used here, because it's nailed to the CleanupMailAddresses function and can't be passed to the array_filter function afaik.
+													// Ideas to avoid this are welcome.
+													if (stripos($prefixMail, $this->config->mail_prefix) === 0) {
+														return TRUE;
 													}
-												);
-					// Set "count" to new value
-					$newcount = count($entries[$i]["$mailField"]);
-					if (array_key_exists("count", $entries[$i]["$mailField"])) {
-						$newcount = $newcount - 1;
-					}
-					$entries[$i]["$mailField"]["count"] = $newcount;
+													return FALSE;
+												}
+											);
+				// Set "count" to new value
+				$newcount = count($entries[$i]["$mailField"]);
+				if (array_key_exists("count", $entries[$i]["$mailField"])) {
+					$newcount = $newcount - 1;
+				}
+				$entries[$i]["$mailField"]["count"] = $newcount;
 
-					// Remove the prefix
-					for ($j = 0; $j < $entries[$i]["$mailField"]["count"]; $j++) {
-						$mailPrefixLen = mb_strlen($mailPrefix);
-						$entries[$i]["$mailField"][$j] = substr($entries[$i]["$mailField"][$j], $mailPrefixLen);
-					}
+				// Remove the prefix
+				for ($j = 0; $j < $entries[$i]["$mailField"]["count"]; $j++) {
+					$mailPrefixLen = mb_strlen($mailPrefix);
+					$entries[$i]["$mailField"][$j] = substr($entries[$i]["$mailField"][$j], $mailPrefixLen);
 				}
 			}
-
-			return $entries;
 		}
+
+		return $entries;
+	}
 
 	/**
 	 * @param array $entry

--- a/plugins/ldap-identities/LdapIdentities.php
+++ b/plugins/ldap-identities/LdapIdentities.php
@@ -69,7 +69,8 @@ class LdapIdentities implements IIdentities
 				$this->config->user_base,
 				$this->config->user_objectclass,
 				$this->config->user_field_name,
-				$this->config->user_field_mail
+				$this->config->user_field_mail,
+				$this->config->mail_prefix
 			);
 		} catch (LdapException $e) {
 			return []; // exceptions are only thrown from the handleerror function that does logging already
@@ -104,7 +105,8 @@ class LdapIdentities implements IIdentities
 				$this->config->group_base,
 				$this->config->group_objectclass,
 				$this->config->group_field_name,
-				$this->config->group_field_mail
+				$this->config->group_field_mail,
+				$this->config->mail_prefix
 			);
 		} catch (LdapException $e) {
 			return []; // exceptions are only thrown from the handleerror function that does logging already
@@ -241,7 +243,7 @@ class LdapIdentities implements IIdentities
 	 * @return LdapResult[]
 	 * @throws LdapException
 	 */
-	private function FindLdapResults(string $searchField, string $searchValue, string $searchBase, string $objectClass, string $nameField, string $mailField): array
+	private function FindLdapResults(string $searchField, string $searchValue, string $searchBase, string $objectClass, string $nameField, string $mailField, string $mailPrefix): array
 	{
 		$this->EnsureBound();
 
@@ -261,6 +263,8 @@ class LdapIdentities implements IIdentities
 			return [];
 		}
 
+		$entries = $this->CleanupMailAddresses($entries, $mailField, $mailPrefix);
+
 		$results = [];
 		for ($i = 0; $i < $entries["count"]; $i++) {
 			$entry = $entries[$i];
@@ -275,6 +279,48 @@ class LdapIdentities implements IIdentities
 
 		return $results;
 	}
+
+		// Function CleanupMailAddresses(): If a prefix is given this function removes addresses without / with the wrong prefix and then the prefix itself from all remaining values.
+		// This is usefull for example for importing Active Directory LDAP entry "proxyAddresses" which can hold different address types with prefixes like "X400:", "smtp:" "sip:" and others.
+
+		/**
+		@param array $entries
+		@param string $mailField
+		@paraam string $mailPrefix
+		@return array
+		*/
+		private function CleanupMailAddresses(array $entries, string $mailField, string $mailPrefix) {
+			if (!empty($mailPrefix)) {
+				for ($i = 0; $i < $entries["count"]; $i++) {
+					// Remove addresses without the given prefix
+					$entries[$i]["$mailField"] = array_filter($entries[$i]["$mailField"],
+													function($prefixMail) {
+														// $mailPrefix can't be used here, because it's nailed to the CleanupMailAddresses function and can't be passed to the array_filter function afaik.
+														// Ideas to avoid this are welcome.
+														if (stripos($prefixMail, $this->config->mail_prefix) === 0) {
+															return TRUE;
+														}
+														return FALSE;
+													}
+												);
+					// Set "count" to new value
+					$newcount = count($entries[$i]["$mailField"]);
+					if (array_key_exists("count", $entries[$i]["$mailField"])) {
+						$newcount = $newcount - 1;
+					}
+					$entries[$i]["$mailField"]["count"] = $newcount;
+
+					// Remove the prefix
+					for ($j = 0; $j < $entries[$i]["$mailField"]["count"]; $j++) {
+						$mailPrefixLen = mb_strlen($mailPrefix);
+						$entries[$i]["$mailField"][$j] = substr($entries[$i]["$mailField"][$j], $mailPrefixLen);
+					}
+				}
+			}
+
+			return $entries;
+		}
+
 
 	/**
 	 * @param array $entry

--- a/plugins/ldap-identities/index.php
+++ b/plugins/ldap-identities/index.php
@@ -67,7 +67,7 @@ class LdapIdentitiesPlugin extends AbstractPlugin
 			Property::NewInstance(LdapConfig::CONFIG_MAIL_PREFIX)
 				->SetLabel("Email prefix")
 				->SetType(PluginPropertyType::STRING)
-				->SetDescription("Only addresses with this prefix will be used as identity. The prefix is removed from the identity list.\nThis is useful for example to import identities from Exchange, which stores mail addresses in the ProxyAddresses attribut of Active Directory with \"smtp:\" as prefix. \(e.g. \"smtp:john.doe@topsecret.info\"\)\n-> To use addresses set by Exchange use \"smtp:\" as prefix.")
+				->SetDescription("Only addresses with this prefix will be used as identity. The prefix is removed from the identity list.\nThis is useful for example to import identities from Exchange, which stores mail addresses in the ProxyAddresses attribut of Active Directory with \"smtp:\" as prefix. (e.g. \"smtp:john.doe@topsecret.info\")\n-> To use addresses set by Exchange use \"smtp:\" as prefix.")
 				->SetDefaultValue(""),
 
 			Property::NewInstance(LdapConfig::CONFIG_BIND_USER)

--- a/plugins/ldap-identities/index.php
+++ b/plugins/ldap-identities/index.php
@@ -8,10 +8,10 @@ class LdapIdentitiesPlugin extends AbstractPlugin
 {
 	const
 		NAME     = 'LDAP Identities',
-		VERSION  = '2.2',
+		VERSION  = '2.3',
 		AUTHOR   = 'FWest98',
 		URL      = 'https://github.com/FWest98',
-		RELEASE  = '2024-02-22',
+		RELEASE  = '2024-02-27',
 		REQUIRED = '2.20.0',
 		CATEGORY = 'Accounts',
 		DESCRIPTION = 'Adds functionality to import account identities from LDAP.';

--- a/plugins/ldap-identities/index.php
+++ b/plugins/ldap-identities/index.php
@@ -57,12 +57,18 @@ class LdapIdentitiesPlugin extends AbstractPlugin
 				->SetLabel("LDAP Protocol Version")
 				->SetType(PluginPropertyType::SELECTION)
 				->SetDefaultValue([2, 3]),
-				
+
 			Property::NewInstance(LdapConfig::CONFIG_STARTTLS)
 				->SetLabel("Use StartTLS")
 				->SetType(PluginPropertyType::BOOL)
 				->SetDescription("Whether or not to use TLS encrypted connection")
 				->SetDefaultValue(true),
+
+			Property::NewInstance(LdapConfig::CONFIG_MAIL_PREFIX)
+				->SetLabel("Email prefix")
+				->SetType(PluginPropertyType::STRING)
+				->SetDescription("Only addresses with this prefix will be used as identity. The prefix is removed from the identity list.\nThis is useful for example to import identities from Exchange, which stores mail addresses in the ProxyAddresses attribut of Active Directory with \"smtp:\" as prefix. \(e.g. \"smtp:john.doe@topsecret.info\"\)\n-> To use addresses set by Exchange use \"smtp:\" as prefix.")
+				->SetDefaultValue(""),
 
 			Property::NewInstance(LdapConfig::CONFIG_BIND_USER)
 				->SetLabel("Bind User DN")


### PR DESCRIPTION
The problem: Exchange saves the mail identities in the ldap attribut "proxyAddresses". This attribut is not only used for mail addresses, but also for SIP, X400 and others (every program can add addresses here with a custom prefix ... or no prefix).
Exchange for example saves the addresses with "smtp:" as prefix e.g. "smtp:john.doe@topsecret.info".
If ldap-identities plugin greps the addresses from the proxyAddresses attribut, it gets all addresses listed there (with prefixes), not only the mail addresses. These identities can't be used to sent mail.

The solution: This solution adds a new entry to the config and a function to cleanup the addresses: If a prefix is set in the config, it removes all addresses without the prefix from the search result (not from the ldap attribut ;) ) and then removes the prefix from the remaining addresses. This way you have only clean mail addresses as identities.