### PR TITLE
Update ImapClient.php

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/MailSo/Imap/ImapClient.php
+++ b/snappymail/v/0.0.0/app/libraries/MailSo/Imap/ImapClient.php
@@ -127,9 +127,6 @@ class ImapClient extends \MailSo\Net\NetClient
 		}
 
 		$type = '';
-		if ($this->Encrypted()) {
-			\array_unshift($oSettings->SASLMechanisms, 'PLAIN', 'LOGIN');
-		}
 		foreach ($oSettings->SASLMechanisms as $sasl_type) {
 			if ($this->hasCapability("AUTH={$sasl_type}") && \SnappyMail\SASL::isSupported($sasl_type)) {
 				$type = $sasl_type;


### PR DESCRIPTION
Closes https://github.com/the-djmaze/snappymail/issues/1485
These lines were overwriting our custom plugin which sets it own auth method via a php unshift. These are already the default login methods, so please don't override what someone may have changed in a plugin.