### PR TITLE
Update plugin ldap-mail-accounts: use SensitiveString for passwords

### DIFF
--- a/plugins/ldap-mail-accounts/LdapMailAccounts.php
+++ b/plugins/ldap-mail-accounts/LdapMailAccounts.php
@@ -208,7 +208,7 @@ class LdapMailAccounts
 				{
 					//Try to login the user with the same password as the primary account has
 					//if this fails the user will see the new mail addresses but will be asked for the correct password
-					$sPass = $oAccount->IncPassword();
+					$sPass = new \SnappyMail\SensitiveString($oAccount->IncPassword());
 					//After creating the accounts here $sUsername is used as username to login to the IMAP server (see Account.php)
 					$oNewAccount = RainLoop\Model\AdditionalAccount::NewInstanceFromCredentials($oActions, $sEmail, $sUsername, $sPass);
 


### PR DESCRIPTION
This updates the plugin [ldap-mail-accounts](https://github.com/the-djmaze/snappymail/tree/master/plugins/ldap-mail-accounts) to use the new SensitiveString class introduced with Snappymail v2.30.0