### PR TITLE
fix: signature editor form is submitted on menu open

### DIFF
--- a/plugins/compact-composer/index.php
+++ b/plugins/compact-composer/index.php
@@ -6,7 +6,7 @@ class CompactComposerPlugin extends \RainLoop\Plugins\AbstractPlugin
 		NAME = 'Compact Composer',
 		AUTHOR = 'Sergey Mosin',
 		URL = 'https://github.com/the-djmaze/snappymail/pull/1466',
-		VERSION = '1.0.1',
+		VERSION = '1.0.2',
 		RELEASE = '2024-02-23',
 		REQUIRED = '2.34.0',
 		LICENSE = 'AGPL v3',

--- a/plugins/compact-composer/js/CompactComposer.js
+++ b/plugins/compact-composer/js/CompactComposer.js
@@ -701,6 +701,7 @@
 							menuWrap.className += ' squire-html-mode-item';
 						}
 						const menuBtn = createElement('button');
+						menuBtn.type = 'button';
 						menuBtn.className = 'btn dropdown-toggle';
 						if (item.icon !== '') {
 							menuBtn.innerHTML = item.icon;


### PR DESCRIPTION
Set menu button element 'type' property to 'button', otherwise Signature Editor closes(wrapper form is submitted) when one of the drop-down menus is open.
