### PR TITLE
Properly escape path separator in `tar.php` file list regex

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/snappymail/tar.php
+++ b/snappymail/v/0.0.0/app/libraries/snappymail/tar.php
@@ -29,7 +29,7 @@ class TAR
 		}
 
 		if ($files) {
-			$files = '/^(' . \implode('|', \array_map('preg_quote', \is_array($files) ? $files : [$files])) . ')/u';
+			$files = '/^(' . \implode('|', \array_map(fn($x): string => preg_quote($x, '/'), \is_array($files) ? $files : [$files])) . ')/u';
 		}
 
 		\clearstatcache(true);


### PR DESCRIPTION
In `tar.php`, the regex delimiter `/` is not properly escaped when building the `$files` regex list. This results in the incorrect regex `/^(snappymail/)/u` on my system. I don't know why seemingly no one else has run into this as I have been unable to find any GH issues related to it. For reference I am running Alpine Linux which uses the Busybox userland and musl libc.

This PR replaces the `array_map` [callable](https://www.php.net/manual/en/function.array-map.php) with an anonymous function that adds the [`delimiter`](https://www.php.net/manual/en/function.preg-quote.php) argument to `preg_quote`. The bad regex above is correctly translated into `/^(snappymail\/)/u` after applying the patch.