### PR TITLE
Update Basque translation

### DIFF
--- a/integrations/nextcloud/snappymail/l10n/eu.json
+++ b/integrations/nextcloud/snappymail/l10n/eu.json
@@ -1,5 +1,5 @@
 { "translations": {
-    "Email" : "Helbide elektronikoa",
+    "Email" : "Posta",
     "Error" : "Errorea",
     "Invalid argument(s)" : "Argumentu baliogabea(k)",
     "Saved successfully" : "Ondo gorde da",


### PR DESCRIPTION
Hello!

We received a report in the Librezale organization about the title of Snappymail not being correct for the Basque translation in the Nextcloud menu.

![image](https://github.com/the-djmaze/snappymail/assets/4324514/17feb93c-3edd-4945-93bf-c91f1741d0a3)

We think `Posta` or `Posta Elektronikoa` is more correct in this case, because we are talking about "Mail" rather than "Address" which would be the `Helbide elektronikoa` that was set earlier, "Helbide" being address. Right now the translation is saying "Email address" rather than "Email".

We have leaned towards `Posta` as we think its understandable enough and `Posta Elektronikoa` was deemed too long for the Nextcloud menu.

If there's any questions or anything else that must be done, please let me know.