### PR TITLE
Fix capabilities when THREAD is disabled

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/MailSo/Imap/ImapClient.php
+++ b/snappymail/v/0.0.0/app/libraries/MailSo/Imap/ImapClient.php
@@ -307,7 +307,7 @@ class ImapClient extends \MailSo\Net\NetClient
 			// Set active capabilities
 			$aList = \array_diff($aList, $this->Settings->disabled_capabilities);
 			if (\in_array('THREAD', $this->Settings->disabled_capabilities)) {
-				$aList = \array_filter($aList, function ($item) { \str_starts_with($item, 'THREAD='); });
+				$aList = \array_filter($aList, function ($item) { return !\str_starts_with($item, 'THREAD='); });
 			}
 		}
 		$this->aCapa = $aList;


### PR DESCRIPTION
- For some reason OAUTHBEARER login wasn't working on my setup
- After a good while spent checking everything from the server to the application.ini, I found that disabling `THREAD` in the domain settings is causing this issue
- So there's a bad `array_filter` here that is causing  capabilities to be set to an empty array whenever `THREAD` is disabled