### PR TITLE
Fix .cryptkey Issue When Switching Between SSO and Non-SSO Accounts

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Model/MainAccount.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Model/MainAccount.php
@@ -16,19 +16,43 @@ class MainAccount extends Account
 	{
 		$oStorage = \RainLoop\Api::Actions()->StorageProvider();
 		$sKey = $oStorage->Get($this, StorageType::ROOT, '.cryptkey');
-		if ($sKey) {
-			$sKey = \SnappyMail\Crypt::DecryptFromJSON($sKey, $oOldPass);
-			if (!$sKey) {
-				throw new ClientException(Notifications::CryptKeyError);
-			}
-			$sKey = \SnappyMail\Crypt::EncryptToJSON($sKey, $this->IncPassword());
+
+		// Get the AppManager from the server container
+		$appManager = \OC::$server->getAppManager();
+		// Check if the OIDC Login app is enabled
+		$isEnabled = $appManager->isEnabledForUser('oidc_login');
+		// If OIDC Login is enabled then we will assign $pwd instead of $this->IncPassword() and $pwd value is taken by following similar approach as https://github.com/the-djmaze/snappymail/blob/0db6c6ab5f9e05c46b13ebbdaf351341710438ac/plugins/login-gmail/index.php#L125
+		if ($isEnabled) {
+			$sUID = \OC::$server->getUserSession()->getUser()->getUID();
+			$pwd = new \SnappyMail\SensitiveString($sUID);
 			if ($sKey) {
-				$this->sCryptKey = null;
-				if (\RainLoop\Api::Actions()->StorageProvider()->Put($this, StorageType::ROOT, '.cryptkey', $sKey)) {
-					return true;
+				$sKey = \SnappyMail\Crypt::DecryptFromJSON($sKey, $pwd);
+				if (!$sKey) {
+					throw new ClientException(Notifications::CryptKeyError);
+				}
+				$sKey = \SnappyMail\Crypt::EncryptToJSON($sKey, $pwd);
+				if ($sKey) {
+					$this->sCryptKey = null;
+					if (\RainLoop\Api::Actions()->StorageProvider()->Put($this, StorageType::ROOT, '.cryptkey', $sKey)) {
+						return true;
+					}
 				}
 			}
-		}
+		} else {
+			if ($sKey) {
+				$sKey = \SnappyMail\Crypt::DecryptFromJSON($sKey, $oOldPass);
+				if (!$sKey) {
+					throw new ClientException(Notifications::CryptKeyError);
+				}
+				$sKey = \SnappyMail\Crypt::EncryptToJSON($sKey, $this->IncPassword());
+				if ($sKey) {
+					$this->sCryptKey = null;
+					if (\RainLoop\Api::Actions()->StorageProvider()->Put($this, StorageType::ROOT, '.cryptkey', $sKey)) {
+						return true;
+					}
+				}
+			}
+		}	
 		return false;
 	}
 
@@ -39,18 +63,43 @@ class MainAccount extends Account
 			// can use the old password to re-seal the cryptkey
 			$oStorage = \RainLoop\Api::Actions()->StorageProvider();
 			$sKey = $oStorage->Get($this, StorageType::ROOT, '.cryptkey');
-			if (!$sKey) {
-				$sKey = \SnappyMail\Crypt::EncryptToJSON(
-					\sha1($this->IncPassword() . APP_SALT),
-					$this->IncPassword()
-				);
-				$oStorage->Put($this, StorageType::ROOT, '.cryptkey', $sKey);
-			}
-			$sKey = \SnappyMail\Crypt::DecryptFromJSON($sKey, $this->IncPassword());
-			if (!$sKey) {
-				throw new ClientException(Notifications::CryptKeyError);
-			}
-			$this->sCryptKey = new SensitiveString(\hex2bin($sKey));
+
+			// Get the AppManager from the server container
+			$appManager = \OC::$server->getAppManager();
+			// Check if the OIDC Login app is enabled
+			$isEnabled = $appManager->isEnabledForUser('oidc_login');
+			// If OIDC Login app is enabled then we will assign $pwd instead of $this->IncPassword() and $pwd value is taken by following similar approach as https://github.com/the-djmaze/snappymail/blob/0db6c6ab5f9e05c46b13ebbdaf351341710438ac/plugins/login-gmail/index.php#L125
+			if ($isEnabled) {
+				$sUID = \OC::$server->getUserSession()->getUser()->getUID();
+				$pwd = new \SnappyMail\SensitiveString($sUID);
+				if (!$sKey) {
+					$sKey = \SnappyMail\Crypt::EncryptToJSON(
+						\sha1($pwd . APP_SALT),
+						$pwd
+					);
+					$oStorage->Put($this, StorageType::ROOT, '.cryptkey', $sKey);
+				}
+				$sKey = \SnappyMail\Crypt::DecryptFromJSON($sKey, $pwd);
+				if (!$sKey) {
+					throw new ClientException(Notifications::CryptKeyError);
+				}
+				$this->sCryptKey = new SensitiveString(\hex2bin($sKey));
+
+			} else {
+				if (!$sKey) {
+					$sKey = \SnappyMail\Crypt::EncryptToJSON(
+						\sha1($this->IncPassword() . APP_SALT),
+						$this->IncPassword()
+					);
+					$oStorage->Put($this, StorageType::ROOT, '.cryptkey', $sKey);
+				}
+				$sKey = \SnappyMail\Crypt::DecryptFromJSON($sKey, $this->IncPassword());
+				if (!$sKey) {
+					throw new ClientException(Notifications::CryptKeyError);
+				}
+				$this->sCryptKey = new SensitiveString(\hex2bin($sKey));
+			}	
+
 		}
 		return $this->sCryptKey;
 	}


### PR DESCRIPTION
**Description:**
This PR addresses an issue related to the .cryptkey file that causes errors when switching accounts after using both Single Sign-On (SSO) and Non-SSO login methods. The problem arises when a .cryptkey file is created during SSO login, which leads to errors when trying to switch accounts after logging in without SSO.

**Steps to Reproduce:**

1. Register a new account.
2. Log in using SSO and add an additional account via SSO. This creates a .cryptkey file in the path: storage/domain/user/.cryptkey.
3. Switch between the accounts — it works as expected.
4. Log out, then log in without SSO.
5. Attempt to switch accounts again — this results in an error, and the following error is logged: [GitHub Issue #1746](https://github.com/the-djmaze/snappymail/issues/1746).

**Fix:**
This PR introduces logic that handles the .cryptkey file properly when switching between SSO and Non-SSO login methods. Specifically, it ensures that the .cryptkey file is appropriately managed when logging in without SSO to prevent conflicts and errors during account switching.

**Impact:**
Users will now be able to switch between accounts smoothly without encountering errors, regardless of whether they log in with SSO or Non-SSO.

**Issue Reference:**
Resolves [Issue #1746](https://github.com/the-djmaze/snappymail/issues/1746).