### PR TITLE
Add dmarc and spf indicators in mail view

### DIFF
--- a/dev/View/User/MailBox/MessageView.js
+++ b/dev/View/User/MailBox/MessageView.js
@@ -199,7 +199,7 @@ export class MailMessageView extends AbstractViewRight {
 			dkimIcon: () => {
 				switch (this.dkimData()[0]) {
 					case 'none':
-						return '';
+						return '🚫︎';
 					case 'pass':
 						return '✔';
 					default:
@@ -215,7 +215,7 @@ export class MailMessageView extends AbstractViewRight {
 			spfIcon: () => {
 				switch (this.spfData()[0]) {
 					case 'none':
-						return '';
+						return '🚫︎';
 					case 'pass':
 						return '✔';
 					default:
@@ -231,7 +231,7 @@ export class MailMessageView extends AbstractViewRight {
 			dmarcIcon: () => {
 				switch (this.dmarcData()[0]) {
 					case 'none':
-						return '';
+						return '🚫︎';
 					case 'pass':
 						return '✔';
 					default:

--- a/dev/View/User/MailBox/MessageView.js
+++ b/dev/View/User/MailBox/MessageView.js
@@ -133,6 +133,8 @@ export class MailMessageView extends AbstractViewRight {
 			// viewer
 			viewFromShort: '',
 			dkimData: ['none', '', ''],
+			spfData: ['none', '', ''],
+			dmarcData: ['none', '', ''],
 			nowTracking: false
 		});
 
@@ -205,10 +207,41 @@ export class MailMessageView extends AbstractViewRight {
 				}
 			},
 			dkimIconClass: () => 'pass' === this.dkimData()[0] ? 'iconcolor-green' : 'iconcolor-red',
-
 			dkimTitle:() => {
 				const dkim = this.dkimData();
 				return dkim[0] ? dkim[2] || 'DKIM: ' + dkim[0] : '';
+			},
+
+			spfIcon: () => {
+				switch (this.spfData()[0]) {
+					case 'none':
+						return '';
+					case 'pass':
+						return '✔';
+					default:
+						return '✖';
+				}
+			},
+			spfIconClass: () => 'pass' === this.spfData()[0] ? 'iconcolor-green' : 'iconcolor-red',
+			spfTitle:() => {
+				const spf = this.spfData();
+				return spf[0] ? spf[2] || 'SPF: ' + spf[0] : '';
+			},
+
+			dmarcIcon: () => {
+				switch (this.dmarcData()[0]) {
+					case 'none':
+						return '';
+					case 'pass':
+						return '✔';
+					default:
+						return '✖';
+				}
+			},
+			dmarcIconClass: () => 'pass' === this.dmarcData()[0] ? 'iconcolor-green' : 'iconcolor-red',
+			dmarcTitle:() => {
+				const dmarc = this.dmarcData();
+				return dmarc[0] ? dmarc[2] || 'DMARC: ' + dmarc[0] : '';
 			},
 
 			showWhitelistOptions: () => 'match' === SettingsUserStore.viewImages(),
@@ -233,6 +266,8 @@ export class MailMessageView extends AbstractViewRight {
 					// TODO: make first param a user setting #683
 					this.viewFromShort(message.from.toString(false, true));
 					this.dkimData(message.dkim[0] || ['none', '', '']);
+					this.spfData(message.spf[0] || ['none', '', '']);
+					this.dmarcData(message.dmarc[0] || ['none', '', '']);
 					this.nowTracking(false);
 				} else {
 					MessagelistUserStore.selectedMessage(null);

--- a/snappymail/v/0.0.0/app/templates/Views/User/MailMessageView.html
+++ b/snappymail/v/0.0.0/app/templates/Views/User/MailMessageView.html
@@ -143,6 +143,8 @@
 			<div class="informationShort">
 				<span class="from" data-bind="html: viewFromShort, attr:{ title: message().from }"></span>
 				<i class="fontastic" data-bind="text: dkimIcon, css: dkimIconClass, attr:{ title: dkimTitle }"></i>
+				<i class="fontastic" data-bind="text: dmarcIcon, css: dmarcIconClass, attr:{ title: dmarcTitle }"></i>
+				<i class="fontastic" data-bind="text: spfIcon, css: spfIconClass, attr:{ title: spfTitle }"></i>
 			</div>
 		</div>
 		<div id="messageItem">


### PR DESCRIPTION
# Done
- Added dmarc and spf indicators, in the same way as the existing dkim icon and hover text

Fixes # #1820