### PR TITLE
Update Html.js to remove x-html tags before rendering

### DIFF
--- a/dev/Common/Html.js
+++ b/dev/Common/Html.js
@@ -308,6 +308,8 @@ export const
 			// Not supported by <template> element
 //			.replace(/<!doctype[^>]*>/gi, '')
 //			.replace(/<\?xml[^>]*\?>/gi, '')
+			// https://github.com/the-djmaze/snappymail/issues/1860
+			.replace(/<(\/?)x-html(\s[^>]*)?>/gi, '')
 			.replace(/<(\/?)head(\s[^>]*)?>/gi, '')
 			.replace(/<(\/?)body(\s[^>]*)?>/gi, '<$1div class="mail-body"$2>')
 //			.replace(/<\/?(html|head)[^>]*>/gi, '')


### PR DESCRIPTION
Remove <x-html></x-html> tags that might be emitted by certain email clients.

Tested by modifying locally using JS debugger and Snappymail JS debug mode.

Fixes the-djmaze/snappymail#1860