### PR TITLE
fr: add an space before the colon

### DIFF
--- a/snappymail/v/0.0.0/app/localization/fr/user.json
+++ b/snappymail/v/0.0.0/app/localization/fr/user.json
@@ -247,7 +247,7 @@
 		"DISCARD_UNSAVED_DATA": "Abandonner les données non enregistrées ?",
 		"ATTACH_FILES": "Joindre des fichiers",
 		"ATTACH_DROP_FILES_DESC": "Glisser les fichiers ici",
-		"REPLY_MESSAGE_TITLE": "%DATETIME% %EMAIL% a écrit",
+		"REPLY_MESSAGE_TITLE": "%DATETIME% %EMAIL% a écrit ",
 		"FORWARD_MESSAGE_TOP_TITLE": "-------- Message transféré -------",
 		"FORWARD_MESSAGE_TOP_SENT": "Envoyé",
 		"EMPTY_TO_ERROR_DESC": "Merci de spécifier au moins un destinataire",


### PR DESCRIPTION
When composing a message in reply to an email, a colon is appended to the message which is translated, in french colon should always be prepended by an unbreakable space.

Add a space in the translation sentence to make sure the space appears before the colon in the interface