### PR TITLE
Add intermediate certificates for S/MIME signing

### DIFF
--- a/dev/Model/Identity.js
+++ b/dev/Model/Identity.js
@@ -24,6 +24,7 @@ export class IdentityModel extends EmailModel /*AbstractModel*/ {
 
 			smimeKey: '',
 			smimeCertificate: '',
+			smimeCertificateChain: '',
 
 			askDelete: false,
 
@@ -33,7 +34,9 @@ export class IdentityModel extends EmailModel /*AbstractModel*/ {
 		addComputablesTo(this, {
 			smimeKeyEncrypted: () => this.smimeKey().includes('-----BEGIN ENCRYPTED PRIVATE KEY-----'),
 			smimeKeyValid: () => /^-----BEGIN (ENCRYPTED |RSA )?PRIVATE KEY-----/.test(this.smimeKey()),
-			smimeCertificateValid: () => /^-----BEGIN CERTIFICATE-----/.test(this.smimeCertificate())
+			smimeCertificateValid: () => /^-----BEGIN CERTIFICATE-----/.test(this.smimeCertificate()),
+			smimeCertificateChainValid: () => !this.smimeCertificateChain()
+				|| /^-----BEGIN CERTIFICATE-----/.test(this.smimeCertificateChain())
 		});
 	}
 

--- a/dev/View/Popup/Compose.js
+++ b/dev/View/Popup/Compose.js
@@ -1413,7 +1413,8 @@ export class ComposePopupView extends AbstractViewPopup {
 		key && options.push(['OpenPGP', key]);
 		key = GnuPGUserStore.getPrivateKeyFor(email, 1);
 		key && options.push(['GnuPG', key]);
-		identity.smimeKeyValid() && identity.smimeCertificateValid() && identity.email === email
+		identity.smimeKeyValid() && identity.smimeCertificateValid()
+			&& identity.smimeCertificateChainValid() && identity.email === email
 			&& options.push(['S/MIME']);
 		console.dir({signOptions: options});
 		this.signOptions(options);
@@ -1610,6 +1611,7 @@ export class ComposePopupView extends AbstractViewPopup {
 					// TODO: sign in PHP fails
 					params.sign = 'S/MIME';
 //					params.signCertificate = identity.smimeCertificate();
+//					params.signCertificateChain = identity.smimeCertificateChain();
 //					params.signPrivateKey = identity.smimeKey();
 //					params.attachCertificate = false;
 					if (identity.smimeKeyEncrypted()) {

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Actions/Messages.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Actions/Messages.php
@@ -1255,6 +1255,7 @@ trait Messages
 			$oPart->SubParts->append($oSignaturePart);
 		} else {
 			$sCertificate = $this->GetActionParam('signCertificate', '');
+			$sCertificateChain = $this->GetActionParam('signCertificateChain', '');
 			$sPrivateKey = $this->GetActionParam('signPrivateKey', '');
 			if ('S/MIME' === $this->GetActionParam('sign', '')) {
 				$sID = $this->GetActionParam('identityID', '');
@@ -1263,6 +1264,7 @@ trait Messages
 					 && ($oIdentity->Id() === $sID || $oIdentity->Email() === $oFrom->GetEmail())
 					) {
 						$sCertificate = $oIdentity->smimeCertificate;
+						$sCertificateChain = $oIdentity->smimeCertificateChain;
 						$sPrivateKey = $oIdentity->smimeKey;
 						break;
 					}
@@ -1303,6 +1305,7 @@ trait Messages
 
 				$SMIME = $this->SMIME();
 				$SMIME->setCertificate($sCertificate);
+				$SMIME->setCertificateChain($sCertificateChain);
 				$SMIME->setPrivateKey($sPrivateKey, $oPassphrase);
 				$sSignature = $SMIME->sign($tmp, $detached);
 

--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Model/Identity.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Model/Identity.php
@@ -31,6 +31,7 @@ class Identity implements \JsonSerializable
 
 	private ?SensitiveString $smimeKey = null;
 	private string $smimeCertificate = '';
+	private string $smimeCertificateChain = '';
 
 	function __construct(string $sId = '', string $sEmail = '')
 	{
@@ -114,6 +115,7 @@ class Identity implements \JsonSerializable
 			$this->pgpSign = !empty($aData['pgpSign']);
 			$this->smimeKey = new SensitiveString(isset($aData['smimeKey']) ? $aData['smimeKey'] : '');
 			$this->smimeCertificate = isset($aData['smimeCertificate']) ? $aData['smimeCertificate'] : '';
+			$this->smimeCertificateChain = isset($aData['smimeCertificateChain']) ? $aData['smimeCertificateChain'] : '';
 			return true;
 		}
 
@@ -136,7 +138,8 @@ class Identity implements \JsonSerializable
 			'pgpEncrypt' => $this->pgpEncrypt,
 			'pgpSign' => $this->pgpSign,
 			'smimeKey' => (string) $this->smimeKey,
-			'smimeCertificate' => $this->smimeCertificate
+			'smimeCertificate' => $this->smimeCertificate,
+			'smimeCertificateChain' => $this->smimeCertificateChain
 		);
 	}
 
@@ -158,6 +161,7 @@ class Identity implements \JsonSerializable
 			'pgpSign' => $this->pgpSign,
 			'smimeKey' => (string) $this->smimeKey,
 			'smimeCertificate' => $this->smimeCertificate,
+			'smimeCertificateChain' => $this->smimeCertificateChain,
 			'exists' => $this->exists
 		);
 	}

--- a/snappymail/v/0.0.0/app/localization/de/user.json
+++ b/snappymail/v/0.0.0/app/localization/de/user.json
@@ -331,6 +331,7 @@
 	"SMIME": {
 		"POPUP_IMPORT_TITLE": "S\/MIME-Zertifikat importieren",
 		"CERTIFICATE": "Zertifikat",
+		"CERTIFICATECHAIN": "Zwischenzertifikat(e)",
 		"CERTIFICATES": "S\/MIME-Zertifikate",
 		"SIGNED_MESSAGE": "S\/MIME-signierte Nachricht",
 		"ENCRYPTED_MESSAGE": "S\/MIME-verschlüsselte Nachricht",

--- a/snappymail/v/0.0.0/app/localization/en/user.json
+++ b/snappymail/v/0.0.0/app/localization/en/user.json
@@ -331,6 +331,7 @@
 	"SMIME": {
 		"POPUP_IMPORT_TITLE": "Import S\/MIME certificate",
 		"CERTIFICATE": "Certificate",
+		"CERTIFICATECHAIN": "Intermediate Certificate(s)",
 		"CERTIFICATES": "S\/MIME Certificates",
 		"SIGNED_MESSAGE": "S\/MIME signed message",
 		"ENCRYPTED_MESSAGE": "S\/MIME encrypted message",

--- a/snappymail/v/0.0.0/app/templates/Views/User/PopupsIdentity.html
+++ b/snappymail/v/0.0.0/app/templates/Views/User/PopupsIdentity.html
@@ -101,6 +101,10 @@
 					<label data-i18n="SMIME/CERTIFICATE"></label>
 					<textarea name="smimeCertificate" class="input-xxlarge" rows="14" autofocus="" autocomplete="off" data-bind="value: smimeCertificate"></textarea>
 				</div>
+				<div class="control-group" data-bind="css: {'error': smimeCertificateChain() && !smimeCertificateChainValid()}">
+					<label data-i18n="SMIME/CERTIFICATECHAIN"></label>
+					<textarea name="smimeCertificateChain" class="input-xxlarge" rows="14" autofocus="" autocomplete="off" data-bind="value: smimeCertificateChain"></textarea>
+				</div>
 				<div class="control-group" data-bind="hidden:smimeCertificate">
 					<label></label>
 					<button type="button" data-bind="click: $root.createSelfSigned" data-i18n="CRYPTO/CREATE_SELF_SIGNED"></button>


### PR DESCRIPTION
Some S/MIME certificates are signed by intermediate certificates that are not contained in the trust store themselves. In order for them to be verifiable, signatures must include the certificate chain.

This PR adds a third field to the S/MIME configuration for identities where those certificates can be added. It is backwards-compatible.