### PR TITLE
Also use ldap login mapping for smtp user

### DIFF
--- a/plugins/ldap-login-mapping/README
+++ b/plugins/ldap-login-mapping/README
@@ -1,1 +1,1 @@
-Plugin which allows you to set up LDAP username by email address (when IMAP/SMTP requires it)
+This plugins allows to authenticate using LDAP mail field, yet login field would still be used for IMAP and SMTP authentication.

--- a/plugins/ldap-login-mapping/index.php
+++ b/plugins/ldap-login-mapping/index.php
@@ -13,7 +13,7 @@ class LDAPLoginMappingPlugin extends AbstractPlugin
 		RELEASE  = '2024-09-20',
 		REQUIRED = '2.36.1',
 		CATEGORY = 'Login',
-		DESCRIPTION = 'Enable custom mapping using ldap field';
+		DESCRIPTION = 'This plugins allows to authenticate using LDAP mail field, yet login field would still be used for IMAP and SMTP authentication';
 	/**
 	 * @var array
 	 */

--- a/plugins/ldap-login-mapping/index.php
+++ b/plugins/ldap-login-mapping/index.php
@@ -8,9 +8,9 @@ class LDAPLoginMappingPlugin extends AbstractPlugin
 {
 	const
 		NAME     = 'LDAP login mapping',
-		VERSION  = '2.3',
+		VERSION  = '2.4',
 		AUTHOR   = 'RainLoop Team, Ludovic Pouzenc<ludovic@pouzenc.fr>, ZephOne<zephone@protonmail.com>',
-		RELEASE  = '2024-09-20',
+		RELEASE  = '2024-01-09',
 		REQUIRED = '2.36.1',
 		CATEGORY = 'Login',
 		DESCRIPTION = 'This plugins allows to authenticate using LDAP mail field, yet login field would still be used for IMAP and SMTP authentication';
@@ -104,6 +104,7 @@ class LDAPLoginMappingPlugin extends AbstractPlugin
 			$sResult = $this->ldapSearch($sEmail);
 			if ( is_array($sResult) ) {
 				$sImapUser = $sResult['login'];
+				$sSmtpUser = $sResult['login'];
 				$sEmail = $sResult['email'];
 			}
 			syslog(LOG_WARNING, "plugins/ldap-login-mapping/index.php:FilterLoginСredentials() auth try: $sIP/$sEmail, resolved as $sImapUser/$sEmail");


### PR DESCRIPTION
After a4299c5f1cef1c2646ef7f91280424597e6dbb40, login mapping in plugin ldap-login-mapping was only effective for IMAP.
In most cases SMTP also use the same LDAP login as IMAP.
This pull request enable mapping to between SMTP login and LDAP login after LDAP search based on mail attribute.