### PR TITLE
Automatically add favicon host to CSP if present

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Api.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Api.php
@@ -42,6 +42,12 @@ abstract class Api
 		$CSP->report = $oConfig->Get('security', 'csp_report', false);
 		$CSP->report_only = $oConfig->Get('debug', 'enable', false); // || SNAPPYMAIL_DEV
 
+		// Allow favicon host, if present
+		$parsedFaviconUrl = parse_url($oConfig->Get('webmail', 'favicon_url', ''));
+		if (is_array($parsedFaviconUrl) && array_key_exists('host', $parsedFaviconUrl)) {
+			$CSP->add('img-src', $parsedFaviconUrl['host']);
+		}
+
 		// Allow https: due to remote images in e-mails or use proxy
 		if (!$oConfig->Get('labs', 'use_local_proxy_for_external_images', '')) {
 			$CSP->add('img-src', 'https:');


### PR DESCRIPTION
Fixes #1890

- Tested with an empty favicon URL (-> No difference)
- Tested with a relative favicon URL (e.g. `/favicon.ico`) (-> No difference)
- Tested with an absolute favicon URL (e.g. `https://my-other-domain.com/favicon.ico`) (-> Adds `my-other-domain.com` to img-src)
- Tested with an absolute favicon URL containing a user and password (e.g. `https://user:pass@my-other-domain.com/favicon.ico`) (-> Correctly adds `my-other-domain.com` to img-src)
- Tested with gibberish (e.g. `dfkgjhdf`) (-> No difference)