### PR TITLE
Fix (docker): Ensure nginx does not listen on ipv6 in ipv4-only environments

### DIFF
--- a/.docker/release/files/entrypoint.sh
+++ b/.docker/release/files/entrypoint.sh
@@ -9,6 +9,12 @@ UPLOAD_MAX_SIZE=${UPLOAD_MAX_SIZE:-25M}
 MEMORY_LIMIT=${MEMORY_LIMIT:-128M}
 SECURE_COOKIES=${SECURE_COOKIES:-true}
 
+# Disable listening on ipv6 for ipv4-only environments, or nginx will fail to start
+if ! ip a | grep 'inet6 ' > /dev/null; then
+    echo "[INFO] ipv6 is disabled. Configuring nginx to not listen on ipv6"
+    sed -i '/listen \[::\]:/d' /etc/nginx/nginx.conf
+fi
+
 # Set attachment size limit
 sed -i "s/<UPLOAD_MAX_SIZE>/$UPLOAD_MAX_SIZE/g" /usr/local/etc/php-fpm.d/php-fpm.conf /etc/nginx/nginx.conf
 sed -i "s/<MEMORY_LIMIT>/$MEMORY_LIMIT/g" /usr/local/etc/php-fpm.d/php-fpm.conf


### PR DESCRIPTION
Just bumped into a little error after upgrading my snappymail after a few months 🥲 

In some of my ipv4 only environments, nginx on the newest snappymail is not starting like in #1324. This appears to be related to the recent change in v2.38.1 #1770 where the `listen <ipv6>` directive was re-added for ipv6-only environments. In #1324, the `listen <ipv6>` was reverted and not added, reason being the official nginx images do not listen on ipv6, very likely to avoid nginx crashing on startup in ipv4-only environments. 

This is a simple fix to not listen on ipv6 if ipv6 is disabled in the kernel or in the container.