### PR TITLE
More compact view of folder list

### DIFF
--- a/dev/Styles/User/FolderList.less
+++ b/dev/Styles/User/FolderList.less
@@ -82,7 +82,7 @@
 			border-left: 3px solid transparent;
 			color: var(--folders-color, #333);
 			display: block;
-			line-height: 34px;
+			line-height: 24px;
 			padding: 0 2em 0 @folderItemPadding;
 			position: relative;
 			text-decoration: none;
@@ -151,7 +151,7 @@
 		color: var(--unread-count-color, #fff);
 		font-size: 80%;
 		line-height: 1.5em;
-		margin-top: 7px;
+		margin-top: 2px;
 		min-width: 1.7em;
 		padding: 1px 4px;
 		text-align: center;


### PR DESCRIPTION
When having many folders, the line-height is too large.
It is reduced to make the view more compact.
Also, the top margin for the number of unread folders will be adapted to fit to the changed line-height.