### PR TITLE
Update include.php to use /home/<username>/.snappymail

### DIFF
--- a/integrations/cpanel/usr/local/cpanel/base/3rdparty/snappymail/include.php
+++ b/integrations/cpanel/usr/local/cpanel/base/3rdparty/snappymail/include.php
@@ -26,7 +26,7 @@
  * Custom 'data' folder path
  */
 if (!empty($_ENV['CPANEL']) && isset($_ENV['HOME'])) {
-	define('APP_DATA_FOLDER_PATH', $_ENV['HOME'] . '/var/snappymail/');
+	define('APP_DATA_FOLDER_PATH', $_ENV['HOME'] . '/.snappymail/');
 } else {
 	exit('Not in cPanel');
 }


### PR DESCRIPTION
Update include.php to use /home/<username>/.snappymail as config/data directory

/home/<username>/var isn´t a standard folder in linux instalation, but put in hidden folder inside home directory is the standard for cpanel addons.

