### PR TITLE
Fix the Cp1252 encoding problem

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/MailSo/Base/Utils.php
+++ b/snappymail/v/0.0.0/app/libraries/MailSo/Base/Utils.php
@@ -59,7 +59,7 @@ abstract class Utils
 				return 'iso-8859-8';
 		}
 
-		return \preg_replace('/^(cp|windows)-?(12[\d]*)/i', 'windows-$1', $sEncoding);
+		return \preg_replace('/^(cp|windows)-?(12[\d]*)/i', 'windows-$2', $sEncoding);
 	}
 
 	public static function NormalizeCharsetByValue(string $sCharset, string $sValue) : string

--- a/snappymail/v/0.0.0/app/libraries/MailSo/Base/Utils.php
+++ b/snappymail/v/0.0.0/app/libraries/MailSo/Base/Utils.php
@@ -59,7 +59,7 @@ abstract class Utils
 				return 'iso-8859-8';
 		}
 
-		return \preg_replace('/^(cp-?|windows?)(12[\d])/', 'windows-$1', $sEncoding);
+		return \preg_replace('/^(cp|windows)-?(12[\d]*)/i', 'windows-$1', $sEncoding);
 	}
 
 	public static function NormalizeCharsetByValue(string $sCharset, string $sValue) : string


### PR DESCRIPTION
Fixed the issue https://github.com/the-djmaze/snappymail/issues/1943.

The regex was not correct: 

- it never returned the digits. So "cp-1252" resulted in "windows-cp"
- it only returned three digits in the secound matching group. So Cp-1252 returned 125 instead of 1252. 

To work with capitalized letters the regex was set to case insensitive, because we only need the number.

 