### PR TITLE
Fix docker command syntax in cli/release.php

### DIFF
--- a/cli/release.php
+++ b/cli/release.php
@@ -244,7 +244,7 @@ else if ($options['docker']) {
 	$zip_filename = "snappymail-{$package->version}.zip";
 	copy($zip_destination, "./.docker/release/{$zip_filename}");
 	if ($docker) {
-		passthru("{$docker} build --pull " . ROOT_DIR . "/.docker/release/ --build-arg FILES_ZIP={$zip_filename} -t snappymail:{$package->version}");
+		passthru("{$docker} build --pull -f " . ROOT_DIR . '/.docker/release/Dockerfile ' . ROOT_DIR . " --build-arg FILES_ZIP={$zip_filename} -t snappymail:{$package->version}");
 	} else {
 		echo "Docker not installed!\n";
 	}


### PR DESCRIPTION
I can't tell if I was missing something obvious, but the docker command was wrong.

It set CWD to `/.docker/release/`, creating errors when attempting to `COPY` files that are in the actual repo root.

The fixed command supplies the Dockerfile through `-f` to build the same thing, but keeps the directory to `ROOT_DIR`, allowing the build to succeed.