### PR TITLE
Fix JS runtime error when forwarding e-mails as attachments

### DIFF
--- a/dev/App/User.js
+++ b/dev/App/User.js
@@ -245,7 +245,7 @@ export class AppUser extends AbstractApp {
 		if (1 == arrayLength(msg)) {
 			msg = msg[0];
 		}
-		if (msg) {
+		if (msg && msg.decrypt) {
 			msg.decrypt().then((/*success*/)=>showScreenPopup(ComposePopupView, params));
 		} else {
 			showScreenPopup(ComposePopupView, params);


### PR DESCRIPTION
A JS error occurs when forwarding multiple e-mails as attachments, using this button: 
<img width="263" height="249" alt="image" src="https://github.com/user-attachments/assets/abf58b0c-b985-40a3-92b4-d7024a773c4b" />

The error complains about t.decrypt being undefined.

This PR fixes that error.