### PR TITLE
feat: client ip passthrough plugin

### DIFF
--- a/plugins/client-ip-passthrough/INSTALL.md
+++ b/plugins/client-ip-passthrough/INSTALL.md
@@ -1,0 +1,136 @@
+# Quick Installation Guide
+
+## Installation Steps
+
+1. **Plugin is already created** at: `plugins/client-ip-passthrough/`
+
+2. **Enable the Plugin:**
+   - Log in to SnappyMail as an administrator
+   - Navigate to: Admin Panel → Plugins
+   - Find "Client IP Passthrough" in the plugin list
+   - Click the "Enable" button
+   - (Optional) Click the settings icon to configure plugin options
+
+3. **Configure Your Reverse Proxy** (Required if behind Nginx/Apache/Cloudflare)
+
+   See the README file for detailed proxy configuration instructions.
+
+## Quick Configuration Checklist
+
+- [ ] Plugin enabled in SnappyMail admin panel
+- [ ] Reverse proxy configured to pass IP headers (if applicable)
+- [ ] "Trust Proxy Headers" enabled in plugin settings (if behind proxy)
+- [ ] Test with a real email send (check SMTP logs)
+- [ ] Test with IMAP login (check IMAP logs if server supports ID command)
+
+## Plugin Settings
+
+All settings can be configured in the SnappyMail Admin Panel after enabling the plugin:
+
+- **Enable SMTP IP Passthrough** (default: ON)
+  - Modifies SMTP EHLO to include client IP
+
+- **Enable IMAP IP Passthrough** (default: ON)
+  - Sends IMAP ID command with client IP after login
+
+- **Trust Proxy Headers** (default: ON)
+  - IMPORTANT: Only enable if behind a trusted reverse proxy
+  - Detects IP from: CF-Connecting-IP, X-Real-IP, X-Forwarded-For
+  - If disabled, only uses REMOTE_ADDR
+
+- **IPv6 Support** (default: ON)
+  - Properly formats IPv6 addresses in EHLO messages
+
+## Testing
+
+### Quick Test - Verify IP Detection
+
+Create this test file in your SnappyMail directory as `test-ip.php`:
+
+```php
+<?php
+echo "Detected IP: ";
+if (!empty($_SERVER["HTTP_CF_CONNECTING_IP"])) {
+    echo $_SERVER["HTTP_CF_CONNECTING_IP"] . " (Cloudflare)";
+} elseif (!empty($_SERVER["HTTP_X_REAL_IP"])) {
+    echo $_SERVER["HTTP_X_REAL_IP"] . " (X-Real-IP)";
+} elseif (!empty($_SERVER["HTTP_X_FORWARDED_FOR"])) {
+    echo explode(',', $_SERVER["HTTP_X_FORWARDED_FOR"])[0] . " (X-Forwarded-For)";
+} elseif (!empty($_SERVER["HTTP_CLIENT_IP"])) {
+    echo $_SERVER["HTTP_CLIENT_IP"] . " (HTTP_CLIENT_IP)";
+} elseif (!empty($_SERVER["REMOTE_ADDR"])) {
+    echo $_SERVER["REMOTE_ADDR"] . " (REMOTE_ADDR)";
+} else {
+    echo "unknown";
+}
+?>
+```
+
+Access: `https://your-domain.com/test-ip.php`
+
+The displayed IP should be your actual client IP, not your proxy's IP.
+
+### Full Test - Check Mail Server Logs
+
+#### SMTP Test:
+1. Log in to SnappyMail
+2. Send a test email
+3. Check SMTP logs: `sudo tail -f /var/log/mail.log`
+4. Look for: `EHLO [your-client-ip]`
+
+#### IMAP Test (if server supports RFC 2971):
+1. Log in to SnappyMail
+2. Check IMAP logs: `sudo tail -f /var/log/dovecot.log`
+3. Look for ID command with client-ip parameter
+
+### Check Plugin Logs
+
+If SnappyMail logging is enabled, check for plugin messages:
+
+```bash
+# View SnappyMail logs
+tail -f data/_data_/_default_/logs/*.log | grep "Client IP Passthrough"
+```
+
+You should see messages like:
+- `Client IP Passthrough: SMTP EHLO set to [192.168.1.100] for user@example.com`
+- `Client IP Passthrough: IMAP ID sent with client-ip=192.168.1.100 for user@example.com`
+
+## Troubleshooting
+
+### Wrong IP Detected?
+
+1. Check that your reverse proxy is configured correctly
+2. Verify proxy headers are being passed (use test-ip.php)
+3. Ensure "Trust Proxy Headers" is enabled in plugin settings
+4. Restart your web server after proxy configuration changes
+
+### Plugin Not Working?
+
+1. Verify plugin is enabled in Admin Panel
+2. Check file permissions: `chmod -R 644 plugins/client-ip-passthrough/`
+3. Check directory permissions: `chmod 755 plugins/client-ip-passthrough/`
+4. Review SnappyMail error logs
+5. Ensure SnappyMail version is 2.36.0 or higher
+
+### IMAP ID Not Sent?
+
+- Your IMAP server may not support RFC 2971 ID extension
+- This is normal - the plugin will detect this and skip sending the command
+- Check "Enable IMAP IP Passthrough" is enabled in settings
+
+## Security Notes
+
+**IMPORTANT:** Only enable "Trust Proxy Headers" if your SnappyMail instance is behind a trusted reverse proxy (Nginx, Apache, Cloudflare, etc.).
+
+If your installation is directly accessible from the internet, disable this option to prevent IP spoofing. The plugin will then only use REMOTE_ADDR.
+
+For Nginx users: Always use `set_real_ip_from` directives to restrict which IPs can set the real IP header.
+
+## Support
+
+For detailed information, see the README file.
+
+For issues or questions:
+- GitHub: https://github.com/the-djmaze/snappymail
+- Documentation: Check the README file in this directory

--- a/plugins/client-ip-passthrough/LICENSE
+++ b/plugins/client-ip-passthrough/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 SnappyMail Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/client-ip-passthrough/README
+++ b/plugins/client-ip-passthrough/README
@@ -1,0 +1,268 @@
+SnappyMail Client IP Passthrough Plugin
+========================================
+
+This plugin for SnappyMail allows you to pass the logged-in user's IP address to your SMTP and IMAP servers. This can be useful for logging, security, and troubleshooting purposes.
+
+How it Works
+------------
+
+• SMTP: The plugin hooks into the smtp.before-connect event and modifies the EHLO message to include the client's IP address. For example: EHLO [192.168.1.100].
+
+• IMAP: The plugin hooks into the imap.after-login event and sends an ID command (RFC 2971) to the IMAP server, including the client's IP address in the command's parameters.
+
+IP Address Detection Priority
+------------------------------
+
+The plugin intelligently detects the client's real IP address by checking headers in the following priority order:
+
+1. CF-Connecting-IP - Cloudflare's header (highest priority)
+2. X-Real-IP - Nginx's real IP header
+3. X-Forwarded-For - Standard proxy header (uses first IP in chain)
+4. HTTP_CLIENT_IP - Less common proxy header
+5. REMOTE_ADDR - Direct connection (no proxy)
+
+This priority order ensures that when SnappyMail is behind Cloudflare or Nginx, the actual client IP is correctly identified rather than the proxy's IP.
+
+Installation
+------------
+
+1. The plugin directory is already created at: plugins/client-ip-passthrough/
+
+2. Enable the Plugin:
+   - Log in to SnappyMail as an administrator
+   - Go to Admin Panel > Plugins
+   - Find "Client IP Passthrough" in the list
+   - Click "Enable"
+   - Configure the plugin settings if needed
+
+Plugin Configuration
+--------------------
+
+The plugin provides the following configuration options in the Admin Panel:
+
+• Enable SMTP IP Passthrough (default: enabled)
+  - Modifies SMTP EHLO message to include client IP address
+
+• Enable IMAP IP Passthrough (default: enabled)
+  - Sends IMAP ID command with client IP address after login
+
+• Trust Proxy Headers (default: enabled)
+  - Enable detection of client IP from proxy headers (CF-Connecting-IP, X-Real-IP, X-Forwarded-For)
+  - IMPORTANT: Only enable if SnappyMail is behind a trusted reverse proxy
+  - If disabled, only REMOTE_ADDR will be used
+
+• IPv6 Support (default: enabled)
+  - Enable IPv6 address support (formats IPv6 addresses correctly for EHLO)
+  - If disabled, IPv6 addresses will fallback to 'localhost' in EHLO
+
+Nginx Configuration
+-------------------
+
+If you're running SnappyMail behind Nginx, you must configure Nginx to pass the client's IP address. Add these headers to your Nginx configuration:
+
+Basic Nginx Configuration:
+
+    location / {
+        proxy_pass http://your-backend;
+
+        # Pass the real client IP to SnappyMail
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $host;
+    }
+
+Nginx Behind Cloudflare:
+
+If your Nginx server is behind Cloudflare, use this configuration to preserve the real client IP:
+
+    # Set real IP from Cloudflare
+    set_real_ip_from 103.21.244.0/22;
+    set_real_ip_from 103.22.200.0/22;
+    set_real_ip_from 103.31.4.0/22;
+    set_real_ip_from 104.16.0.0/13;
+    set_real_ip_from 104.24.0.0/14;
+    set_real_ip_from 108.162.192.0/18;
+    set_real_ip_from 131.0.72.0/22;
+    set_real_ip_from 141.101.64.0/18;
+    set_real_ip_from 162.158.0.0/15;
+    set_real_ip_from 172.64.0.0/13;
+    set_real_ip_from 173.245.48.0/20;
+    set_real_ip_from 188.114.96.0/20;
+    set_real_ip_from 190.93.240.0/20;
+    set_real_ip_from 197.234.240.0/22;
+    set_real_ip_from 198.41.128.0/17;
+    set_real_ip_from 2400:cb00::/32;
+    set_real_ip_from 2606:4700::/32;
+    set_real_ip_from 2803:f800::/32;
+    set_real_ip_from 2405:b500::/32;
+    set_real_ip_from 2405:8100::/32;
+    set_real_ip_from 2c0f:f248::/32;
+    set_real_ip_from 2a06:98c0::/29;
+
+    # Use CF-Connecting-IP as the real IP
+    real_ip_header CF-Connecting-IP;
+
+    location / {
+        proxy_pass http://your-backend;
+
+        # Pass both Cloudflare and Nginx headers
+        proxy_set_header CF-Connecting-IP $http_cf_connecting_ip;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $host;
+    }
+
+Note: Keep the Cloudflare IP ranges updated. You can get the latest list from: https://www.cloudflare.com/ips/
+
+After Changing Nginx Configuration:
+
+Always test and reload Nginx after making changes:
+
+    # Test configuration
+    sudo nginx -t
+
+    # Reload Nginx
+    sudo systemctl reload nginx
+
+Apache Configuration
+--------------------
+
+If you're using Apache as a reverse proxy, add these directives:
+
+    <VirtualHost *:80>
+        ProxyPreserveHost On
+
+        # Pass client IP headers
+        RequestHeader set X-Forwarded-For "%{REMOTE_ADDR}s"
+        RequestHeader set X-Real-IP "%{REMOTE_ADDR}s"
+
+        ProxyPass / http://your-backend/
+        ProxyPassReverse / http://your-backend/
+    </VirtualHost>
+
+For Cloudflare with Apache, install and configure mod_cloudflare:
+
+    # Install mod_cloudflare
+    wget https://www.cloudflare.com/static/misc/mod_cloudflare/mod_cloudflare.c
+    apxs -a -i -c mod_cloudflare.c
+
+    # Restart Apache
+    sudo systemctl restart apache2
+
+Cloudflare Configuration
+-------------------------
+
+When using Cloudflare, the plugin automatically detects the CF-Connecting-IP header, which contains the real client IP. No additional Cloudflare configuration is needed, but ensure:
+
+1. Your Nginx/Apache is configured to pass the CF-Connecting-IP header (see above)
+2. You trust Cloudflare's IP ranges in your set_real_ip_from directives
+3. The "Trust Proxy Headers" option is enabled in the plugin settings
+
+Testing
+-------
+
+To verify that the plugin is working correctly, you will need to monitor your mail server's logs.
+
+Testing SMTP EHLO Passthrough:
+
+1. Log in to SnappyMail and send an email.
+2. Check your SMTP server's log file (e.g., /var/log/mail.log for Postfix/Exim on Debian/Ubuntu, or /var/log/maillog on CentOS/RHEL).
+3. Look for a line showing the EHLO command with the client's IP address, e.g.:
+   EHLO [192.168.1.100]
+
+Testing IMAP ID Passthrough:
+
+1. Log in to SnappyMail.
+2. Check your IMAP server's log file (e.g., /var/log/dovecot.log for Dovecot).
+3. You should see a line indicating that the ID command was received with the client's IP address. The exact log message will depend on your IMAP server's configuration and logging level. For Dovecot, you may need to enable more verbose logging to see the full command.
+
+Verifying IP Detection:
+
+Create a test PHP file to verify which IP is being detected:
+
+    <?php
+    echo "Detected IP: ";
+    if (!empty($_SERVER["HTTP_CF_CONNECTING_IP"])) {
+        echo $_SERVER["HTTP_CF_CONNECTING_IP"] . " (Cloudflare)";
+    } elseif (!empty($_SERVER["HTTP_X_REAL_IP"])) {
+        echo $_SERVER["HTTP_X_REAL_IP"] . " (X-Real-IP)";
+    } elseif (!empty($_SERVER["HTTP_X_FORWARDED_FOR"])) {
+        echo explode(',', $_SERVER["HTTP_X_FORWARDED_FOR"])[0] . " (X-Forwarded-For)";
+    } elseif (!empty($_SERVER["HTTP_CLIENT_IP"])) {
+        echo $_SERVER["HTTP_CLIENT_IP"] . " (HTTP_CLIENT_IP)";
+    } elseif (!empty($_SERVER["REMOTE_ADDR"])) {
+        echo $_SERVER["REMOTE_ADDR"] . " (REMOTE_ADDR)";
+    } else {
+        echo "unknown";
+    }
+    ?>
+
+Place this in your SnappyMail directory and access it via your browser. The displayed IP should match your actual client IP, not the proxy or Cloudflare IP.
+
+Plugin Logs:
+
+If SnappyMail logging is enabled, the plugin will write informational messages when:
+- SMTP EHLO is modified with client IP
+- IMAP ID command is sent with client IP
+- IMAP ID command fails (warning level)
+
+Check your SnappyMail logs (typically in data/_data_/_default_/logs/) for entries prefixed with "Client IP Passthrough:".
+
+Important Considerations
+------------------------
+
+• Proxy Servers: This plugin is designed to work when SnappyMail is behind reverse proxies like Nginx, Apache, or Cloudflare. Proper proxy configuration is required for accurate IP detection.
+
+• Security: Only trust proxy headers from known proxy servers. If your Nginx is publicly accessible, malicious users could spoof these headers. Always use set_real_ip_from to restrict which IPs can set the real IP. You can disable the "Trust Proxy Headers" option in the plugin settings to only use REMOTE_ADDR.
+
+• IMAP Server Support: The IMAP ID command is an extension (RFC 2971) and may not be supported by all IMAP servers. If your server does not support it, the command will be ignored, and no error will be displayed.
+
+• IPv6 Support: The plugin automatically handles both IPv4 and IPv6 addresses correctly when IPv6 support is enabled in settings.
+
+Troubleshooting
+---------------
+
+Wrong IP Address Detected:
+
+If the plugin is detecting the wrong IP (e.g., showing Cloudflare's IP or Nginx's IP):
+
+1. Verify your Nginx/Apache configuration includes the proxy headers
+2. Restart your web server after configuration changes
+3. Use the test file above to check which headers are being received
+4. Check that set_real_ip_from includes your proxy's IP ranges
+5. Ensure "Trust Proxy Headers" is enabled in plugin settings
+
+Plugin Not Working:
+
+1. Verify the plugin is enabled in SnappyMail admin panel
+2. Check file permissions on the plugin directory (should be readable by web server)
+3. Review SnappyMail error logs for any plugin errors
+4. Ensure the plugin file is named exactly index.php
+5. Check that your SnappyMail version meets the minimum requirement (2.36.0+)
+
+IMAP ID Not Sent:
+
+1. Verify "Enable IMAP IP Passthrough" is enabled in plugin settings
+2. Check if your IMAP server supports the ID extension (RFC 2971)
+3. Review SnappyMail logs for "Client IP Passthrough" messages
+4. Some IMAP servers may silently ignore the ID command if not supported
+
+SMTP EHLO Not Modified:
+
+1. Verify "Enable SMTP IP Passthrough" is enabled in plugin settings
+2. Check SMTP server logs to see what EHLO message is received
+3. Review SnappyMail logs for "Client IP Passthrough" messages
+4. Ensure proxy headers are being passed correctly (test with the PHP snippet above)
+
+License
+-------
+
+MIT License - See LICENSE file for details
+
+Support
+-------
+
+For issues, questions, or contributions, please visit:
+https://github.com/the-djmaze/snappymail

--- a/plugins/client-ip-passthrough/index.php
+++ b/plugins/client-ip-passthrough/index.php
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * Client IP Passthrough Plugin for SnappyMail
+ *
+ * This plugin passes the logged-in user's real IP address to SMTP and IMAP servers.
+ * It intelligently detects the client IP through various proxy headers and:
+ * - Modifies SMTP EHLO message to include the client IP (e.g., EHLO [192.168.1.100])
+ * - Sends IMAP ID command (RFC 2971) with the client IP after login
+ *
+ * IP Detection Priority:
+ * 1. CF-Connecting-IP (Cloudflare)
+ * 2. X-Real-IP (Nginx)
+ * 3. X-Forwarded-For (Standard proxy - first IP)
+ * 4. HTTP_CLIENT_IP (Less common proxy)
+ * 5. REMOTE_ADDR (Direct connection)
+ */
+class ClientIpPassthroughPlugin extends \RainLoop\Plugins\AbstractPlugin
+{
+	const
+		NAME        = 'Client IP Passthrough',
+		AUTHOR      = 'SnappyMail Community',
+		URL         = 'https://github.com/the-djmaze/snappymail',
+		VERSION     = '1.0',
+		RELEASE     = '2025-01-28',
+		REQUIRED    = '2.36.0',
+		CATEGORY    = 'Network',
+		LICENSE     = 'MIT',
+		DESCRIPTION = 'Passes the client\'s real IP address to SMTP and IMAP servers for logging and security purposes';
+
+	/**
+	 * Initialize the plugin and register hooks
+	 */
+	public function Init() : void
+	{
+		// Hook into SMTP connection to modify EHLO message
+		$this->addHook('smtp.before-connect', 'ModifySmtpEhlo');
+
+		// Hook into IMAP after-login to send ID command
+		$this->addHook('imap.after-login', 'SendImapIdCommand');
+	}
+
+	/**
+	 * Configure plugin settings
+	 */
+	protected function configMapping() : array
+	{
+		return array(
+			\RainLoop\Plugins\Property::NewInstance('enable_smtp')
+				->SetLabel('Enable SMTP IP Passthrough')
+				->SetType(\RainLoop\Enumerations\PluginPropertyType::BOOL)
+				->SetDescription('Modify SMTP EHLO message to include client IP address')
+				->SetDefaultValue(true),
+
+			\RainLoop\Plugins\Property::NewInstance('enable_imap')
+				->SetLabel('Enable IMAP IP Passthrough')
+				->SetType(\RainLoop\Enumerations\PluginPropertyType::BOOL)
+				->SetDescription('Send IMAP ID command with client IP address after login')
+				->SetDefaultValue(true),
+
+			\RainLoop\Plugins\Property::NewInstance('trust_proxies')
+				->SetLabel('Trust Proxy Headers')
+				->SetType(\RainLoop\Enumerations\PluginPropertyType::BOOL)
+				->SetDescription('Enable detection of client IP from proxy headers (CF-Connecting-IP, X-Real-IP, X-Forwarded-For). Only enable if behind a trusted reverse proxy.')
+				->SetDefaultValue(true),
+
+			\RainLoop\Plugins\Property::NewInstance('ipv6_support')
+				->SetLabel('IPv6 Support')
+				->SetType(\RainLoop\Enumerations\PluginPropertyType::BOOL)
+				->SetDescription('Enable IPv6 address support (formats IPv6 addresses correctly for EHLO)')
+				->SetDefaultValue(true)
+		);
+	}
+
+	/**
+	 * Detect the client's real IP address with priority order
+	 *
+	 * @return string Client IP address or 'unknown' if not detectable
+	 */
+	private function getClientIp() : string
+	{
+		$trustProxies = $this->Config()->Get('plugin', 'trust_proxies', true);
+
+		// If we don't trust proxies, only use REMOTE_ADDR
+		if (!$trustProxies) {
+			return $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+		}
+
+		// Priority 1: Cloudflare's CF-Connecting-IP header
+		if (!empty($_SERVER['HTTP_CF_CONNECTING_IP'])) {
+			return $this->cleanIpAddress($_SERVER['HTTP_CF_CONNECTING_IP']);
+		}
+
+		// Priority 2: Nginx's X-Real-IP header
+		if (!empty($_SERVER['HTTP_X_REAL_IP'])) {
+			return $this->cleanIpAddress($_SERVER['HTTP_X_REAL_IP']);
+		}
+
+		// Priority 3: X-Forwarded-For header (use first IP in chain)
+		if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+			$ips = \explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
+			return $this->cleanIpAddress(\trim($ips[0]));
+		}
+
+		// Priority 4: HTTP_CLIENT_IP header (less common)
+		if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
+			return $this->cleanIpAddress($_SERVER['HTTP_CLIENT_IP']);
+		}
+
+		// Priority 5: Direct connection via REMOTE_ADDR
+		if (!empty($_SERVER['REMOTE_ADDR'])) {
+			return $this->cleanIpAddress($_SERVER['REMOTE_ADDR']);
+		}
+
+		return 'unknown';
+	}
+
+	/**
+	 * Clean and validate IP address
+	 *
+	 * @param string $ip Raw IP address
+	 * @return string Cleaned IP address
+	 */
+	private function cleanIpAddress(string $ip) : string
+	{
+		$ip = \trim($ip);
+
+		// Remove port if present (e.g., "192.168.1.1:8080" or "[::1]:8080")
+		$ip = \preg_replace('/:\d+$/', '', $ip);
+
+		// Remove brackets from IPv6 if present
+		$ip = \trim($ip, '[]');
+
+		return $ip;
+	}
+
+	/**
+	 * Format IP address for SMTP EHLO message
+	 *
+	 * @param string $ip IP address
+	 * @return string Formatted IP for EHLO (IPv4 wrapped in brackets, IPv6 as-is with brackets)
+	 */
+	private function formatIpForEhlo(string $ip) : string
+	{
+		if ($ip === 'unknown') {
+			return 'localhost';
+		}
+
+		// Check if IPv6 (contains colons)
+		if (\strpos($ip, ':') !== false) {
+			if (!$this->Config()->Get('plugin', 'ipv6_support', true)) {
+				return 'localhost';
+			}
+			// IPv6 addresses in EHLO should be in brackets
+			return '[' . $ip . ']';
+		}
+
+		// IPv4 addresses should be wrapped in brackets for EHLO
+		// e.g., EHLO [192.168.1.100]
+		return '[' . $ip . ']';
+	}
+
+	/**
+	 * Hook: Modify SMTP EHLO message to include client IP
+	 *
+	 * @param \RainLoop\Model\Account $oAccount
+	 * @param \MailSo\Smtp\SmtpClient $oSmtpClient
+	 * @param array $aSmtpCredentials
+	 */
+	public function ModifySmtpEhlo(\RainLoop\Model\Account $oAccount,
+		\MailSo\Smtp\SmtpClient $oSmtpClient,
+		array &$aSmtpCredentials) : void
+	{
+		// Check if SMTP passthrough is enabled
+		if (!$this->Config()->Get('plugin', 'enable_smtp', true)) {
+			return;
+		}
+
+		$clientIp = $this->getClientIp();
+
+		// Only modify EHLO if we successfully detected an IP
+		if ($clientIp !== 'unknown') {
+			$aSmtpCredentials['Ehlo'] = $this->formatIpForEhlo($clientIp);
+
+			// Log the modification if logging is enabled
+			if ($this->Manager()->Actions()->Logger()) {
+				$this->Manager()->Actions()->Logger()->Write(
+					'Client IP Passthrough: SMTP EHLO set to ' . $aSmtpCredentials['Ehlo'] . ' for ' . $oAccount->Email(),
+					\LOG_INFO,
+					'PLUGIN'
+				);
+			}
+		}
+	}
+
+	/**
+	 * Hook: Send IMAP ID command with client IP after login
+	 *
+	 * @param \RainLoop\Model\Account $oAccount
+	 * @param \MailSo\Imap\ImapClient $oImapClient
+	 * @param bool $bLoginResult
+	 * @param \MailSo\Imap\Settings $oSettings
+	 */
+	public function SendImapIdCommand(\RainLoop\Model\Account $oAccount,
+		\MailSo\Imap\ImapClient $oImapClient,
+		bool $bLoginResult,
+		\MailSo\Imap\Settings $oSettings) : void
+	{
+		// Only proceed if IMAP passthrough is enabled and login was successful
+		if (!$this->Config()->Get('plugin', 'enable_imap', true) || !$bLoginResult) {
+			return;
+		}
+
+		// Check if server supports ID command (RFC 2971)
+		if (!$oImapClient->hasCapability('ID')) {
+			return;
+		}
+
+		$clientIp = $this->getClientIp();
+
+		// Only send ID command if we successfully detected an IP
+		if ($clientIp === 'unknown') {
+			return;
+		}
+
+		try {
+			// Build ID parameters array per RFC 2971
+			// Format: ID ("name" "SnappyMail" "version" "2.x" "client-ip" "192.168.1.100")
+			$idParams = [
+				'name', 'SnappyMail',
+				'version', defined('APP_VERSION') ? APP_VERSION : '2.x',
+				'client-ip', $clientIp
+			];
+
+			// Send ID command
+			// The IMAP ID command format is: ID (<key> <value> <key> <value> ...)
+			$oImapClient->SendRequestGetResponse('ID', [$idParams]);
+
+			// Log the ID command if logging is enabled
+			if ($this->Manager()->Actions()->Logger()) {
+				$this->Manager()->Actions()->Logger()->Write(
+					'Client IP Passthrough: IMAP ID sent with client-ip=' . $clientIp . ' for ' . $oAccount->Email(),
+					\LOG_INFO,
+					'PLUGIN'
+				);
+			}
+		} catch (\Throwable $oException) {
+			// Log error but don't fail the login
+			if ($this->Manager()->Actions()->Logger()) {
+				$this->Manager()->Actions()->Logger()->Write(
+					'Client IP Passthrough: Failed to send IMAP ID command: ' . $oException->getMessage(),
+					\LOG_WARNING,
+					'PLUGIN'
+				);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This plugin for SnappyMail allows you to pass the logged-in user's IP address to your SMTP and IMAP servers. This can be useful for logging, security, and troubleshooting purposes.

How it Works
• SMTP: The plugin hooks into the smtp.before-connect event and modifies the EHLO message to include the client's IP address. For example: EHLO [192.168.1.100].
• IMAP: The plugin hooks into the imap.after-login event and sends an ID command (RFC 2971) to the IMAP server, including the client's IP address in the command's parameters.

IP Address Detection Priority

The plugin intelligently detects the client's real IP address by checking headers in the following priority order:

1. CF-Connecting-IP - Cloudflare's header (highest priority)
2. X-Real-IP - Nginx's real IP header
3. X-Forwarded-For - Standard proxy header (uses first IP in chain)
4. HTTP_CLIENT_IP - Less common proxy header
5. REMOTE_ADDR - Direct connection (no proxy)

This priority order ensures that when SnappyMail is behind Cloudflare or Nginx, the actual client IP is correctly identified rather than the proxy's IP.