### PR TITLE
Fix(auth): Correct OIDC login by using SensitiveString object.

### DIFF
--- a/integrations/nextcloud/snappymail/lib/Util/SnappyMailHelper.php
+++ b/integrations/nextcloud/snappymail/lib/Util/SnappyMailHelper.php
@@ -176,7 +176,8 @@ class SnappyMailHelper
 			// If OpenID Connect (OIDC) is enabled and used for login, use this.
 			if (static::isOIDCLogin()) {
 				$sEmail = $config->getUserValue($sUID, 'settings', 'email');
-				return [$sUID, $sEmail, "oidc_login|{$sUID}"];
+				$pwd = new \SnappyMail\SensitiveString("oidc_login|{$sUID}");
+				return [$sUID, $sEmail, $pwd];
 			}
 
 			// Only use the user's password in the current session if they have


### PR DESCRIPTION
Resolves a regression where OIDC (OpenID Connect) Single Sign-On (SSO) login failed to complete due to a type mismatch in credential handling https://github.com/the-djmaze/snappymail/issues/2006

SnappyMail's internal security and client logic expect sensitive credentials to be an instance of the \SnappyMail\SensitiveString class for safety.