### PR TITLE
Update SSLContext.php: fixed typo in line 42, to reference correct class

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/MailSo/Net/SSLContext.php
+++ b/snappymail/v/0.0.0/app/libraries/MailSo/Net/SSLContext.php
@@ -39,7 +39,7 @@ class SSLContext implements \JsonSerializable
 
 	public function __construct()
 	{
-		$oConfig = \RainLoop\API::Config();
+		$oConfig = \RainLoop\Api::Config();
 		$this->verify_peer = !!$oConfig->Get('ssl', 'verify_certificate', true);
 		$this->verify_peer_name = !!$oConfig->Get('ssl', 'verify_certificate', true);
 		$this->allow_self_signed = !!$oConfig->Get('ssl', 'allow_self_signed', false);


### PR DESCRIPTION
The reference to class RainLoop\API is invalid, the author obviously meant class RainLoop\Api