### PR TITLE
fixed typo in imapsync.php: was "RainLoop\API" instead of "RainLoop\Api"

### DIFF
--- a/snappymail/v/0.0.0/imapsync.php
+++ b/snappymail/v/0.0.0/imapsync.php
@@ -183,7 +183,7 @@ function getImapClient(int $host)
 
 	$oImapClient = new \MailSo\Imap\ImapClient;
 //	$oAccount = new \RainLoop\Model\Account;
-	$oImapClient->SetLogger(\RainLoop\API::Logger());
+	$oImapClient->SetLogger(\RainLoop\Api::Logger());
 //	$oPlugins->RunHook('imap.before-connect', array($oAccount, $oImapClient, $ImapSettings));
 	$oImapClient->Connect($ImapSettings);
 //	$oPlugins->RunHook('imap.after-connect', array($oAccount, $oImapClient, $ImapSettings));


### PR DESCRIPTION
In line 186, there was a reference to class „RainLoop\API“ which does not exist. The author obviously meant class „RainLoop\Api“.