### PR TITLE
Fix login-remote plugin password handling

### DIFF
--- a/plugins/login-remote/index.php
+++ b/plugins/login-remote/index.php
@@ -43,6 +43,7 @@ class LoginRemotePlugin extends \RainLoop\Plugins\AbstractPlugin
 			try
 			{
 				static::$login = true;
+				$sPassword = new \SnappyMail\SensitiveString($sPassword);
 				$oAccount = $oActions->LoginProcess($sEmail, $sPassword);
 			}
 			catch (\Throwable $oException)


### PR DESCRIPTION
login-remote plugin stopped working as Snappymail now requires a SensitiveString parameter.