### PR TITLE
FIX non-compliant Autocrypt Header

### DIFF
--- a/dev/View/Popup/Compose.js
+++ b/dev/View/Popup/Compose.js
@@ -1634,7 +1634,9 @@ export class ComposePopupView extends AbstractViewPopup {
 					Object.entries(PgpUserStore.getPublicKeyOfEmails(recipients) || {}).forEach(([k,v]) =>
 						params.autocrypt.push({
 							addr: k,
-							keydata: v.replace(/-----(BEGIN|END) PGP PUBLIC KEY BLOCK-----/g, '').trim()
+							keydata: v
+								.replace(/-----(BEGIN|END) PGP PUBLIC KEY BLOCK-----/g, '')
+								.replace(/\s+/g, '') // Single base64 string, let the server do compliance formatting
 						})
 					);
 				for (let i = 0; i < encryptOptions.length; ++i) {


### PR DESCRIPTION
Fixes https://github.com/the-djmaze/snappymail/issues/2038

Remove all spaces, including \n, from armored public key and let the server do compliance formatting. 