### PR TITLE
HTTP: send associative extra headers correctly (breaks CardDAV upload)

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/snappymail/http/request/curl.php
+++ b/snappymail/v/0.0.0/app/libraries/snappymail/http/request/curl.php
@@ -47,7 +47,14 @@ class CURL extends \SnappyMail\HTTP\Request
 			\curl_setopt($c, CURLOPT_CAINFO, $this->ca_bundle);
 		}
 		if ($extra_headers) {
-			\curl_setopt($c, CURLOPT_HTTPHEADER, $extra_headers);
+			// CURLOPT_HTTPHEADER expects a flat list of "Name: value" strings.
+			// Callers may pass an associative array, in which case curl sends
+			// the bare values as malformed header lines and drops them.
+			$aHeaderLines = array();
+			foreach ($extra_headers as $mKey => $sValue) {
+				$aHeaderLines[] = \is_int($mKey) ? $sValue : "{$mKey}: {$sValue}";
+			}
+			\curl_setopt($c, CURLOPT_HTTPHEADER, $aHeaderLines);
 		}
 		if ($this->auth['user'] && $this->auth['type']) {
 			if ($this->auth['type'] & self::AUTH_BEARER ) {

--- a/snappymail/v/0.0.0/app/libraries/snappymail/http/request/socket.php
+++ b/snappymail/v/0.0.0/app/libraries/snappymail/http/request/socket.php
@@ -43,7 +43,12 @@ class Socket extends \SnappyMail\HTTP\Request
 			$extra_headers['Authorization'] = static::$Authorization[$host];
 		}
 		if ($extra_headers) {
-			$headers = \array_merge($headers, $extra_headers);
+			// $headers is a flat list of "Name: value" strings, so an
+			// associative $extra_headers would lose its keys in the implode()
+			// below and emit bare values as malformed header lines.
+			foreach ($extra_headers as $mKey => $sValue) {
+				$headers[] = \is_int($mKey) ? $sValue : "{$mKey}: {$sValue}";
+			}
 		}
 		$headers = \implode("\r\n", $headers);
 		if (!\is_null($body)) {


### PR DESCRIPTION
Both HTTP request drivers assume `$extra_headers` is a flat list of `"Name: value"` strings, but callers pass an associative array.

The most visible caller is the CardDAV provider, which sends

```php
array("Content-Type" => "text/vcard; charset=utf-8")
```

from `RainLoop\Providers\AddressBook\CardDAV::davClientRequest()`.

### What goes wrong

* **curl** — `CURLOPT_HTTPHEADER` receives the map as-is, so curl emits the bare value `text/vcard; charset=utf-8` as a header line and discards it as malformed.
* **socket** — `array_merge()` followed by `implode("\r\n", $headers)` keeps only the values, producing the same malformed line.

Either way the header is lost, and because a body is present the request falls back to `Content-Type: application/x-www-form-urlencoded`. `socket.php` even appends that fallback explicitly.

A CardDAV server is entitled to refuse that content type. Cyrus IMAP answers a vCard `PUT` with:

```xml
403 <D:error xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav"><C:supported-address-data/></D:error>
```

So **every contact upload fails while the download half of the sync succeeds**, and the sync silently behaves as import-only. The failure surfaces only as `PdoAddressBook[WARNING]: Update/create remote failed` in the log.

### How it was confirmed

Same vCard body, same server, same collection, varying only the header:

| Content-Type | Result |
| --- | --- |
| `text/vcard; charset=utf-8` | `201 Created` |
| `application/x-www-form-urlencoded` | `403 supported-address-data` |
| `text/plain` | `403 supported-address-data` |
| *(none)* | `201 Created` |

After the patch, a `PUT` issued through `SnappyMail\DAV\Client` returns `201`.

### The change

Normalise string keys to `"Name: value"` in both drivers; integer keys pass through untouched, so callers already supplying a flat list are unaffected.