### PR TITLE
AddressBook: do not let an empty side wipe the other during sync

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/AddressBook/PdoAddressBook.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/AddressBook/PdoAddressBook.php
@@ -160,6 +160,31 @@ class PdoAddressBook
 
 		$bReadWrite = $this->isDAVReadWrite();
 
+		/**
+		 * An empty list on either side is far more often a fault than a real
+		 * "delete everything": a fresh or rebuilt local store, a DAV listing
+		 * that failed to parse, a stale server-side index. Acting on it
+		 * destroys data the other side still holds, so skip the deletions in
+		 * that direction and let the following import/export reconcile.
+		 */
+		$iLocalLive = 0;
+		foreach ($aLocalSyncData as $aGuardData) {
+			if (empty($aGuardData['deleted'])) {
+				++$iLocalLive;
+			}
+		}
+		$iRemoteCount = \count($aRemoteSyncData);
+		$bProtectRemote = (0 === $iLocalLive && 0 < $iRemoteCount);
+		$bProtectLocal  = (0 === $iRemoteCount && 0 < $iLocalLive);
+		if ($bProtectRemote) {
+			\SnappyMail\Log::warning('PdoAddressBook', "Sync() local store is empty while remote holds"
+				. " {$iRemoteCount} contacts: importing only, no remote deletions");
+		}
+		if ($bProtectLocal) {
+			\SnappyMail\Log::warning('PdoAddressBook', "Sync() remote listing is empty while local holds"
+				. " {$iLocalLive} contacts: keeping local, no local deletions");
+		}
+
 		// Delete remote when Mode = read + write
 		if ($bReadWrite) {
 			\SnappyMail\Log::info('PdoAddressBook', 'Sync() is import and export');
@@ -168,7 +193,7 @@ class PdoAddressBook
 				if ($aData['deleted']) {
 					++$iCount;
 					unset($aLocalSyncData[$sKey]);
-					if (isset($aRemoteSyncData[$sKey], $aRemoteSyncData[$sKey]['vcf'])) {
+					if (!$bProtectRemote && isset($aRemoteSyncData[$sKey], $aRemoteSyncData[$sKey]['vcf'])) {
 						\SnappyMail\HTTP\Stream::JSON(['messsage'=>"Delete remote {$sKey}"]);
 						$this->davClientRequest($oClient, 'DELETE', $sPath.$aRemoteSyncData[$sKey]['vcf']);
 					}
@@ -183,9 +208,11 @@ class PdoAddressBook
 
 		// Delete local
 		$aIdsForDeletion = array();
-		foreach ($aLocalSyncData as $sKey => $aData) {
-			if (!empty($aData['etag']) && !isset($aRemoteSyncData[$sKey])) {
-				$aIdsForDeletion[] = $aData['id_contact'];
+		if (!$bProtectLocal) {
+			foreach ($aLocalSyncData as $sKey => $aData) {
+				if (!empty($aData['etag']) && !isset($aRemoteSyncData[$sKey])) {
+					$aIdsForDeletion[] = $aData['id_contact'];
+				}
 			}
 		}
 		if (\count($aIdsForDeletion)) {


### PR DESCRIPTION
In `PdoAddressBook::Sync()` an empty list on either side is treated as authoritative:

* a local contact holding an `etag` but missing from the remote listing is **deleted locally** — so an empty or unparsed listing removes every previously synced contact;
* a local tombstone is **deleted remotely** — so a local store that is empty apart from tombstones prunes the server.

An empty list is far more often a fault than a genuine "delete everything": a fresh or rebuilt local store, a listing that failed to parse, a stale server-side index, a transient auth problem.

### How this showed up

On a Cyrus IMAP server the per-user DAV index had lost its records, so the addressbook `PROPFIND` returned `0` entries while the mailbox still held 40 vCards. The first sync logged:

```
PdoAddressBook[INFO]: 0 remote contacts
PdoAddressBook[INFO]: 17 local contacts
PdoAddressBook[INFO]: 5 local contacts removed
```

and hard-deleted contacts that existed on both sides moments earlier. Recovery required reading unvacuumed dead tuples out of PostgreSQL. Note the local deletion runs regardless of `Mode`, so read-only does not protect against it.

### The change

Skip the deletions in whichever direction the *source* list is empty, and let the existing import/export reconcile instead:

| Local live | Remote | Remote deletions | Local deletions |
| --- | --- | --- | --- |
| 0 | > 0 | **skipped** | allowed |
| 0 (tombstones only) | > 0 | **skipped** | allowed |
| > 0 | 0 | allowed | **skipped** |
| > 0 | > 0 | allowed | allowed |

Both guards log a warning naming the counts, so a skipped pass is visible rather than silent. When both sides hold data the behaviour is unchanged.

This is deliberately conservative: it can delay propagating a legitimate "user emptied the addressbook" by one sync, which seems a fair trade against silent data loss.