### PR TITLE
ics-viewer: unwrap attachments and widen the calendar part match

### DIFF
--- a/plugins/ics-viewer/message.js
+++ b/plugins/ics-viewer/message.js
@@ -86,10 +86,17 @@
 							});
 						}
 					});
-					// ICS attachment
-//					let ics = msg.attachments.find(attachment => 'application/ics' == attachment.mimeType);
-
-					let ics = msg.attachments.find(attachment => 'text/calendar' == attachment.mimeType);
+					// ICS attachment.
+					// attachments is a ko.observableArray, so it must be
+					// unwrapped before array methods are used on it.
+					// A scheduling mail does not always carry a text/calendar
+					// attachment either: the part is often inline inside
+					// multipart/alternative and repeated as application/ics.
+					let ics = (msg.attachments() || []).find(attachment =>
+						'text/calendar' == attachment.mimeType
+						|| 'application/ics' == attachment.mimeType
+						|| 'text/x-vcalendar' == attachment.mimeType
+						|| /\.ics$/i.test(attachment.fileName || ''));
 					if (ics && ics.download) {
 
 						// fetch it and parse the VEVENT


### PR DESCRIPTION
The ICS panel never appears on a real invitation. Two causes.

### 1. `attachments` is a `ko.observableArray`

```js
let ics = msg.attachments.find(attachment => "text/calendar" == attachment.mimeType);
```

`ko.observableArray` does not expose `find()`, so this is `undefined` and throws inside the `view.message.subscribe()` callback — taking the rest of the handler, including the JSON-LD path above it, down with it. The application itself consistently writes `attachments()` (e.g. `this.attachments().length`).

### 2. The scheduling part is not always a `text/calendar` attachment

A typical invitation from Evolution or Exchange arrives as:

```
multipart/mixed
├── multipart/alternative
│   ├── text/plain
│   └── text/calendar; method=REQUEST     <- inline, not an attachment
└── application/ics; name=invite.ics      <- the attachment
```

`BodyStructure::FileName()` names the inline part `calendar-<partid>.ics`, so the user sees **two** `.ics` files while the `text/calendar` test matches unreliably. Matching `text/calendar`, `application/ics`, `text/x-vcalendar` or an `.ics` file name covers the shapes in the wild — which is what the commented-out line directly above was reaching for.

### Verified

Against a real invitation whose `text/calendar` part is inline and whose attachment is `application/ics`, the panel now renders. Found while building a separate plugin that acts on invitations; the same two mistakes were in my code.