### PR TITLE
Let plugins register a navigation entry

### DIFF
--- a/dev/Common/Plugins.js
+++ b/dev/Common/Plugins.js
@@ -1,3 +1,4 @@
+import ko from 'ko';
 import { settingsAddViewModel } from 'Screen/AbstractSettings';
 import { SettingsGet } from 'Common/Globals';
 import { AbstractViewPopup } from 'Knoin/AbstractViews';
@@ -13,6 +14,35 @@ const USER_VIEW_MODELS_HOOKS = [],
  */
 rl.pluginRemoteRequest = (callback, action, parameters, timeout) => {
 	rl.app.Remote.request('Plugin' + action, callback, parameters, timeout);
+};
+
+/**
+ * Navigation entries contributed by plugins, rendered in the folder list
+ * toolbar beside Compose and Contacts.
+ * @type {Array}
+ */
+export const pluginNavEntries = ko.observableArray();
+
+/**
+ * Register a navigation entry for a screen a plugin provides.
+ *
+ * Without this a plugin that adds a screen has to reach into the folder list
+ * template itself, which several already do, each in its own way.
+ *
+ * @param {Object} entry
+ * @param {string} entry.icon  character or glyph shown on the button
+ * @param {string} entry.title tooltip
+ * @param {string=} entry.hash location hash to navigate to
+ * @param {Function=} entry.click called instead of setting the hash
+ */
+rl.addNavEntry = entry => {
+	if (entry && entry.icon) {
+		pluginNavEntries.push({
+			icon: entry.icon,
+			title: entry.title || '',
+			click: entry.click || (() => { hasher.setHash(entry.hash || ''); })
+		});
+	}
 };
 
 /**

--- a/dev/View/User/MailBox/FolderList.js
+++ b/dev/View/User/MailBox/FolderList.js
@@ -7,6 +7,7 @@ import { mailBox, settings } from 'Common/Links';
 import { addComputablesTo } from 'External/ko';
 
 import { AppUserStore } from 'Stores/User/App';
+import { pluginNavEntries } from 'Common/Plugins';
 import { SettingsUserStore } from 'Stores/User/Settings';
 import { FolderUserStore } from 'Stores/User/Folder';
 import { MessageUserStore } from 'Stores/User/Message';
@@ -36,6 +37,7 @@ export class MailFolderList extends AbstractViewLeft {
 		this.moveAction = moveAction;
 
 		this.allowContacts = AppUserStore.allowContacts();
+		this.pluginNavEntries = pluginNavEntries;
 
 		this.foldersFilter = foldersFilter;
 

--- a/snappymail/v/0.0.0/app/templates/Views/User/MailFolderList.html
+++ b/snappymail/v/0.0.0/app/templates/Views/User/MailFolderList.html
@@ -5,6 +5,9 @@
 			<span class="buttonComposeText" data-i18n="FOLDER_LIST/BUTTON_NEW_MESSAGE"></span>
 		</a>
 		<a class="btn buttonContacts fontastic" data-bind="visible: allowContacts, click: contactsClick" data-i18n="[title]GLOBAL/CONTACTS">📇</a>
+		<!-- ko foreach: pluginNavEntries -->
+		<a class="btn buttonPluginNav fontastic" data-bind="text: icon, attr: { title: title }, click: click"></a>
+		<!-- /ko -->
 	</div>
 	<div class="b-content">
 		<ul class="b-folders-system" data-bind="foreach: systemFolders">


### PR DESCRIPTION
A plugin that adds a screen currently has no way to offer a way into it.

The folder list toolbar holds Compose and Contacts and is not extensible, so plugins reach into the UI themselves. A CalDAV plugin I maintain did this:

```js
const checkButton = setInterval(() => {
    const contactsBtn = document.querySelector(".buttonContacts");
    if (contactsBtn && !contactsBtn.dataset.popoverInit) { … }
}, 500);
```

It polls for the Contacts button, replaces its icon with a grid, and hangs a popover off it. So the Contacts button stops looking like Contacts, the calendar lives somewhere no other mail client puts it, and the whole thing depends on a timing race. Every plugin that adds a screen solves this differently.

### Proposal

```js
rl.addNavEntry({ icon: "📅", title: "Calendar", hash: "#/calendar" });
```

The entry is appended to the folder list toolbar and rendered with the same `.btn fontastic` classes as the existing buttons, so it follows the active theme. `click` may be supplied instead of `hash` when the plugin opens a popup rather than routing.

### Cost

* `dev/Common/Plugins.js` — one `observableArray` and one function, beside the existing `rl.addSettingsViewModel`.
* `dev/View/User/MailBox/FolderList.js` — expose it on the view model.
* `MailFolderList.html` — a three-line `foreach`.

No behaviour changes when no plugin registers anything: the array is empty and the `foreach` renders nothing.

I am happy to adjust the placement, the naming, or to render the entries somewhere other than that toolbar if you would prefer a different home for them.