### PR TITLE
Admin panel: accept trusted proxy-auth header (X-NC-Admin) on the admin host

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Actions/Admin.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Actions/Admin.php
@@ -14,6 +14,15 @@ trait Admin
 	public function IsAdminLoggined(bool $bThrowExceptionOnFalse = true) : bool
 	{
 		if ($this->Config()->Get('security', 'allow_admin_panel', true)) {
+			// [PATCH ronzz.org] OIDC bridge: nginx auth_request (webmail-admin.ronzz.org)
+			// sets X-NC-Admin after validating the Nextcloud session. Honored only on the
+			// dedicated admin host (admin_panel.host); the header is stripped/overridden
+			// at nginx for any other path.
+			if (!empty($_SERVER['HTTP_X_NC_ADMIN'])
+				&& \strtolower((string) $this->Config()->Get('admin_panel', 'host', '')) === \strtolower($this->Http()->GetHost()))
+			{
+				return true;
+			}
 			$sAdminKey = $this->getAdminAuthKey();
 			if ($sAdminKey && $this->Cacher(null, true)->Get(KeyPathHelper::SessionAdminKey($sAdminKey))) {
 				return true;


### PR DESCRIPTION
## Summary

Adds optional **trusted proxy-authentication for the admin panel**: when a request carries the `X-NC-Admin` header **and** the `Host` matches `admin_panel.host`, `IsAdminLoggined()` grants the admin session directly. This lets an external SSO layer (e.g. an nginx `auth_request` gate validated against an OpenID Connect / Nextcloud session) open the panel **without embedding an OIDC client in SnappyMail**.

## Why

The webmail *user* login validates against IMAP, but the *admin* panel is plain web auth — the natural place for SSO. SnappyMail's admin session is only issuable through `DoAdminLogin` (private `setAdminAuthToken`, no plugin hook), so the only clean integration point for a trusted upstream is this session check. The same pattern is standard for reverse-proxy auth (cf. the `login-proxyauth` / `proxy-auth` plugins, which only cover the user login path).

## Security model

- The header is honored **only when `admin_panel.host` is set and the request `Host` equals it** — so it is inert on the normal webmail vhost and when `admin_panel.host` is unset (the feature is off by default).
- It is the *reverse proxy's* job to strip client-supplied headers and set `X-NC-Admin` only after a successful auth check (same trust model as `proxy-auth`).
- When the header is absent, behavior is unchanged: the existing `admin_login` / `admin_password` (+ optional `admin_totp`) check applies.

## Example (nginx)

```nginx
server {
    server_name webmail-admin.example.org;
    # ... ssl, root, fastcgi to SnappyMail ...
    location ~ \.php$ {
        auth_request /_oidc-auth;                       # validated elsewhere
        auth_request_set $nc_admin $upstream_http_x_nc_admin;
        fastcgi_param HTTP_X_NC_ADMIN $nc_admin;        # overrides any client value
        fastcgi_pass unix:/run/php/snappymail-fpm.sock;
        include fastcgi_params;
    }
}
```

With `admin_panel.host = "webmail-admin.example.org"` in `application.ini`.

## Notes

- 9-line addition, no behavior change when unused; PHP 8.x compatible.
- In production at `webmail-admin.ronzz.org` (Nextcloud as OIDC IdP via the `oidc` app + FastAPI sidecar + nginx `auth_request`), since 2026-08-16.
