### PR TITLE
Don't reset the message list to page 1 and clear the search on message.show

### DIFF
--- a/dev/View/User/MailBox/MessageList.js
+++ b/dev/View/User/MailBox/MessageList.js
@@ -303,14 +303,14 @@ export class MailMessageList extends AbstractViewRight {
 				item => sFolder === item?.folder && iUid == item?.uid
 			);
 
-			if ('INBOX' === sFolder) {
+			if ('INBOX' === sFolder && 'INBOX' !== FolderUserStore.currentFolderFullName()) {
 				hasher.setHash(mailBox(sFolder));
 			}
 
 			if (message) {
 				this.selector.selectMessageItem(message);
 			} else {
-				if ('INBOX' !== sFolder) {
+				if ('INBOX' !== sFolder && sFolder !== FolderUserStore.currentFolderFullName()) {
 					hasher.setHash(mailBox(sFolder));
 				}
 				if (sFolder && iUid) {


### PR DESCRIPTION
### What happens

While browsing any page other than the first, or while looking at search results, the message list suddenly jumps back to page 1 of the INBOX with an empty search box, and the request that was in flight is aborted.

From the user's point of view the search "returns nothing" and the pagination "doesn't work". There is no error message, which makes it hard to report — it took a look at the server access log to see what was really going on.

### Why

`dev/View/User/MailBox/MessageList.js`, in the `mailbox.message.show` handler:

```js
if ('INBOX' === sFolder) {
    hasher.setHash(mailBox(sFolder));
}
```

`mailBox(sFolder)` with no further arguments means *page 1, no search*, and the hash is rewritten even when the user is already in that folder. Because the hash of an open message carries the message id and the new one does not, the two differ, the route fires again, the message is shown again, and the handler runs again — a loop. Every iteration aborts whatever request was pending.

The event is fired by desktop notifications (`dispatchMessage`) and by "show next message" after a move or delete. The same unconditional `setHash` a few lines below, for non-INBOX folders, has the same problem.

### Evidence

nginx access log from one user session on a production server, with the base64 payloads decoded and the search terms replaced. Every request that was not "page 1, no search" ended in HTTP 499 with 0 bytes, and in the **same second** the browser asked for `offset=0, search=""`:

```
11:23:05  499  0  MessageList  {"folder":"INBOX","offset":0, "search":"<term>"    }
11:23:06  304  0  MessageList  {"folder":"INBOX","offset":0, "search":""}
12:17:56  499  0  MessageList  {"folder":"INBOX","offset":0, "search":"subject=<term>"}
12:17:56  304  0  MessageList  {"folder":"INBOX","offset":0, "search":""}
13:48:30  499  0  MessageList  {"folder":"INBOX","offset":80,"search":""}
13:48:30  304  0  MessageList  {"folder":"INBOX","offset":0, "search":""}
13:49:20  499  0  MessageList  {"folder":"INBOX","offset":20,"search":""}
13:49:20  304  0  MessageList  {"folder":"INBOX","offset":0, "search":""}
```

The loop is visible as well: for about 25 seconds the client requested the same two messages plus the message list once per second.

This is **not** a slow-server problem. On that same server the IMAP side answers page 2 of a 47,893-message mailbox in 39 ms.

### The change

Only navigate when we are not already in that folder. This keeps the useful behaviour — clicking a new-mail notification while in another folder still takes you to the INBOX — and removes both the destructive reset and the loop. When the message is not in the current page, the `else` branch already opens it in the preview pane without touching the list.

`FolderUserStore` is already imported in the file, so no new import is needed.

### Testing

Applied to 2.38.2 on a production server with two brands and 27 mailboxes, patching the built `static/js/app.js` and `static/js/min/app.min.js` with the equivalent change. Verified in a browser: page 2 stays on page 2, and a search keeps its results instead of bouncing back. Both files pass `node --check`, and the app boots with no console errors.

Version: 2.38.2, and the code is unchanged in current `master`.