### PR TITLE
ldap-contacts-suggestions: search several base DNs

### DIFF
--- a/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
+++ b/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
@@ -139,29 +139,41 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 			$sFilter .= (1 < count($aItems) ? '(|' : '').$sSubFilter.(1 < count($aItems) ? ')' : '');
 			$sFilter .= ')';
 
-			$this->logWrite('ldap_search: start: '.$sBaseDn.' / '.$sFilter, \LOG_INFO, 'LDAP');
-			$oS = @\ldap_search($oCon, $sBaseDn, $sFilter, $aItems, 0, 30, 30);
-			if ($oS) {
-				$aEntries = @\ldap_get_entries($oCon, $oS);
-				if (is_array($aEntries)) {
-					if (isset($aEntries['count'])) {
-						unset($aEntries['count']);
-					}
+			// A directory rarely keeps everything worth suggesting in one branch:
+			// meeting rooms and other bookable resources commonly live outside
+			// the people branch. Searching a single subtree either misses them,
+			// or - if the base is widened to the domain root - drags every
+			// service account into the suggestion list. Base DNs are therefore
+			// separated by '|', which cannot appear unescaped in a DN, so an
+			// existing single-branch configuration keeps working unchanged.
+			$aBaseDns = \array_filter(\array_map('trim', \explode('|', $sBaseDn)), 'strlen');
 
-					foreach ($aEntries as $aItem) {
-						if ($aItem) {
-							$sName = $sEmail = '';
-							list ($sEmail, $sName) = $this->findNameAndEmail($aItem, $aEmails, $aNames, $aUIDs);
-							if (!empty($sEmail)) {
-								$aResult[] = array($sEmail, $sName);
+			foreach ($aBaseDns as $sOneBaseDn) {
+				$this->logWrite('ldap_search: start: '.$sOneBaseDn.' / '.$sFilter, \LOG_INFO, 'LDAP');
+				$oS = @\ldap_search($oCon, $sOneBaseDn, $sFilter, $aItems, 0, 30, 30);
+				if ($oS) {
+					$aEntries = @\ldap_get_entries($oCon, $oS);
+					if (is_array($aEntries)) {
+						if (isset($aEntries['count'])) {
+							unset($aEntries['count']);
+						}
+
+						foreach ($aEntries as $aItem) {
+							if ($aItem) {
+								$sName = $sEmail = '';
+								list ($sEmail, $sName) = $this->findNameAndEmail($aItem, $aEmails, $aNames, $aUIDs);
+								if (!empty($sEmail)) {
+									$aResult[] = array($sEmail, $sName);
+								}
 							}
 						}
+					} else {
+						$this->logLdapError($oCon, 'ldap_get_entries');
 					}
 				} else {
-					$this->logLdapError($oCon, 'ldap_get_entries');
+					// One unreachable branch must not silence the others.
+					$this->logLdapError($oCon, 'ldap_search ('.$sOneBaseDn.')');
 				}
-			} else {
-				$this->logLdapError($oCon, 'ldap_search');
 			}
 		}
 

--- a/plugins/ldap-contacts-suggestions/index.php
+++ b/plugins/ldap-contacts-suggestions/index.php
@@ -4,8 +4,8 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 {
 	const
 		NAME     = 'Contacts suggestions (LDAP)',
-		VERSION  = '2.14',
-		RELEASE  = '2024-03-12',
+		VERSION  = '2.15',
+		RELEASE  = '2026-08-19',
 		REQUIRED = '2.35.3',
 		CATEGORY = 'Contacts',
 		DESCRIPTION = 'Get contacts suggestions from LDAP.';
@@ -79,7 +79,7 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 				->SetType(\RainLoop\Enumerations\PluginPropertyType::PASSWORD)
 				->SetDefaultValue(''),
 			\RainLoop\Plugins\Property::NewInstance('base_dn')->SetLabel('Search base DN')
-				->SetDescription('DN to use as the search base. Supported tokens: {domain}, {domain:dc}, {email}, {email:user}, {email:domain}, {login}, {imap:login}, {imap:host}, {imap:port}')
+				->SetDescription('DN to use as the search base. Supported tokens: {domain}, {domain:dc}, {email}, {email:user}, {email:domain}, {login}, {imap:login}, {imap:host}, {imap:port} Several branches may be given, separated by | - useful when meeting rooms or other resources live outside the people branch.')
 				->SetDefaultValue('ou=People,dc=example,dc=com'),
 			\RainLoop\Plugins\Property::NewInstance('object_classes')->SetLabel('objectClasses')
 				->SetDescription('LDAP objectClasses to search for, comma separated list')


### PR DESCRIPTION
### Problem

The plugin queries a single `base_dn`. A directory rarely keeps everything worth
suggesting in one branch: people typically sit in a people branch, while meeting
rooms and other bookable resources are kept in a separate one.

So while composing an invitation, typing part of a room's name returns nothing.
The entry exists and matches the filter; it is simply outside the single subtree
being searched.

Widening `base_dn` to the domain root is not a workaround: it pulls every
service and role account into the suggestion list.

### Change

`base_dn` accepts several branches separated by `|`:

```
ou=People,dc=example,dc=com|ou=Resources,dc=example,dc=com
```

Each branch is queried with the same filter and the results are concatenated.

- **Backwards compatible.** `|` cannot appear unescaped in a DN, so an existing
  single-branch value parses to a one-element list and behaves exactly as before.
- **One bad branch no longer hides the rest.** The failed search is logged with
  its own DN and the loop continues; previously a single `ldap_search` failure
  discarded the whole lookup.
- Token substitution (`{domain}`, `{email}`…) is unchanged: it is applied to the
  whole string before splitting, so tokens work in every branch.
- Setting description and plugin version (2.15) updated.

### Testing

Against OpenLDAP with people in `ou=People,dc=example,dc=com` and three rooms in
`ou=Resources,dc=example,dc=com`, searching `room`:

| `base_dn` | results |
|---|---|
| `ou=People,dc=example,dc=com` | 0 |
| `ou=People,dc=example,dc=com\|ou=Resources,dc=example,dc=com` | 3 rooms, no service accounts |

Single-branch configurations were re-checked to confirm unchanged behaviour.
