### PR TITLE
PdoAddressBook: GetContactByEmail() passed the wrong columns

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/AddressBook/PdoAddressBook.php
+++ b/snappymail/v/0.0.0/app/libraries/RainLoop/Providers/AddressBook/PdoAddressBook.php
@@ -723,14 +723,20 @@ class PdoAddressBook
 			$aParams[':search_lower'] = array($sLowerSearch, \PDO::PARAM_STR);
 		}
 
-		$oContact = null;
-		$iIdContact = 0;
+		// This query selects id_contact only, so it must not be handed to
+		// getContactsFromPDO(), which unconditionally reads id_contact_str,
+		// changed, etag and jcard from every row. Look the contact up by id
+		// instead: GetContactByID() selects those columns, so the Contact it
+		// returns carries a real etag and changed value rather than 0.
+		$oStmt = $this->prepareAndExecute($sSql, $aParams);
+		if ($oStmt) {
+			$aFetch = $oStmt->fetchAll(\PDO::FETCH_ASSOC);
+			if (\is_array($aFetch) && \count($aFetch) && !empty($aFetch[0]['id_contact'])) {
+				return $this->GetContactByID((int) $aFetch[0]['id_contact']);
+			}
+		}
 
-		$aContacts = $this->getContactsFromPDO(
-			$this->prepareAndExecute($sSql, $aParams)
-		);
-
-		return $aContacts ? $aContacts[0] : null;
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
`GetContactByEmail()` runs

```sql
SELECT DISTINCT id_contact FROM rainloop_ab_properties WHERE ...
```

and hands the statement to `getContactsFromPDO()`, which unconditionally reads
`id_contact_str`, `changed`, `etag` and `jcard` from every row. None of those
are selected, so every match raises three PHP warnings:

```
Undefined array key "id_contact_str"   PdoAddressBook.php
Undefined array key "changed"          PdoAddressBook.php
Undefined array key "etag"             PdoAddressBook.php
```

and the `Contact` that comes back carries `IdContactStr` `''` with `Changed`
and `Etag` both `0` — values a CardDAV sync would use.

### Why it is easy to miss

The lookup still works. With no `jcard` column either, every row falls into the
follow-up properties query, so the **contact data is right** and only the
metadata is wrong. Nothing looks broken to a user.

It is not rare either: the bundled **avatars** plugin calls
`GetContactByEmail()` for the sender of a message, so opening a mailbox
triggers it repeatedly — 23 warnings in a single session on one of our
installs, in a log that already grows by megabytes a day.

### The fix

Look the contact up by id instead. `GetContactByID()` already selects exactly
the columns `getContactsFromPDO()` expects, so the `Contact` comes back
complete, and the search query keeps doing the one thing it is good at —
finding the id. The unused `$oContact` and `$iIdContact` locals go with it.

Query count is unchanged in practice: the current path already issues a second
query, because the missing `jcard` sends every row through the follow-up
properties lookup.

### Verification

This layer has no test suite upstream, so rather than add one I reproduced the
behaviour against a real PDO — the two queries as they are written, feeding the
reading logic copied from `getContactsFromPDO()` verbatim, with PHP warnings
promoted to exceptions so they cannot be missed:

| | before | after |
|---|---|---|
| columns returned | `id_contact` only | all five |
| reading the row | warns on `id_contact_str` | no warning |
| `IdContactStr` | `''` | the real value |
| `Changed` | `0` | the real timestamp |

Happy to shape this differently if you would rather fix it inside
`getContactsFromPDO()` — I chose the caller because the other two callers
already select the right columns, so the reader is not the part that is wrong.
