### PR TITLE
HtmlUtils: strip every data-* attribute, not just the first one

### DIFF
--- a/snappymail/v/0.0.0/app/libraries/MailSo/Base/HtmlUtils.php
+++ b/snappymail/v/0.0.0/app/libraries/MailSo/Base/HtmlUtils.php
@@ -160,12 +160,19 @@ abstract class HtmlUtils
 
 		// Remove all remaining data-* attributes
 		foreach ($xpath->query('//*[@*[starts-with(name(), "data-")]]') as $oElement) {
-			$sTagNameLower = \strtolower($oElement->nodeName);
 			if ($oElement->hasAttributes()) {
+				// DOMNamedNodeMap is live: removing the attribute the foreach is
+				// currently on ends the iteration, so exactly one data-* was
+				// removed per element however many it carried. Collect the
+				// names first, then remove.
+				$aNames = [];
 				foreach ($oElement->attributes as $oAttr) {
 					if ('data-' === \substr(\strtolower($oAttr->nodeName), 0, 5)) {
-						$oElement->removeAttribute($oAttr->nodeName);
+						$aNames[] = $oAttr->nodeName;
 					}
+				}
+				foreach ($aNames as $sName) {
+					$oElement->removeAttribute($sName);
 				}
 			}
 		}


### PR DESCRIPTION
`BuildHtml()` iterates `$oElement->attributes` — a **live** `DOMNamedNodeMap` — and calls `removeAttribute()` on the attribute the `foreach` is currently on. That ends the iteration: the loop sees no further attribute, so **exactly one `data-*` is removed per element, however many it carries**.

The comment says *"Remove all remaining data-\* attributes"*; that is not what the loop does.

### Measured

PHP 8.5.10, libxml 2.12.5, running the existing loop in isolation. `data-*` left behind, and what the `foreach` actually visited:

| input | visited | `data-*` left |
|---|---|---|
| `<p data-a="1">` | `data-a` | *(none)* |
| `<p data-a="1" data-b="2">` | `data-a` | `data-b` |
| `<p data-a="1" data-b="2" data-c="3">` | `data-a` | `data-b`, `data-c` |
| `<p data-a="1" data-b="2" data-c="3" data-d="4">` | `data-a` | `data-b`, `data-c`, `data-d` |
| `<p data-a="1" class="keep" data-b="2">` | `data-a` | `data-b` *(`class` is kept, as intended)* |
| `<p DATA-A="1" data-b="2">` | `data-a` | `data-b` |

Standalone reproduction:

```php
$d = new DOMDocument();
$d->loadHTML('<p data-a="1" data-b="2" data-c="3">x</p>');
$x = new DOMXPath($d);
foreach ($x->query('//*[@*[starts-with(name(), "data-")]]') as $e) {
    foreach ($e->attributes as $a) {
        if ('data-' === substr(strtolower($a->nodeName), 0, 5)) {
            $e->removeAttribute($a->nodeName);
        }
    }
}
// $e still carries data-b and data-c
```

Removing the *current* attribute ends the loop; removing a *later* one only skips it; removing an *earlier* one has no effect. So an ascending index loop would leave about half of them, and the `foreach` leaves all but the first.

### Where this runs

`BuildHtml()` has a single call site — `buildMessage()` in `RainLoop/Actions/Messages.php` — reached from **both** `DoSaveMessage()` and `DoSendMessage()`, exactly as the docblock on `BuildHtml()` says. So the attributes that survive end up in the message that is sent, and in the draft that is `APPEND`ed and later read back.

It is not on the display path: an incoming message body is decoded and charset-converted in `MailSo\Mail\Message::fromFetchResponse()` and handed to the browser as-is, where `dev/Common/Html.js` filters it with allowlists of tags and attributes. Worth saying plainly, though: the HTML reaching `BuildHtml()` is often *derived* from a received message — replying or forwarding hands the editor content that came from somewhere else — so it is not simply our own markup.

### The fix

Collect the names first, then remove them. One file. Idempotent, and it leaves non-`data-` attributes untouched.

Two notes for whoever reviews, neither of which this PR changes:

* `removeAttribute()` resolves by qualified name, so an attribute whose *prefix* starts with `data-` (`data-p:foo`) is removed correctly; `removeAttributeNS()` is not needed here.
* The XPath predicate `starts-with(name(), "data-")` is case-sensitive while the inner filter uses `strtolower()`. Under `loadHTML()` the parser lowercases attribute names, so this never shows; under `loadXML()` an element carrying only `DATA-*` would not be selected at all. Pre-existing, and out of scope here.

I found this while auditing the CSP of a deployment, checking whether a `data-bind` could reach Knockout from message HTML. It cannot. But that made me look at this loop, and it does not do what it says.
